### PR TITLE
Access files to analyze through FileAccess trait

### DIFF
--- a/src/file_access.rs
+++ b/src/file_access.rs
@@ -53,7 +53,7 @@ impl<'a> FileAccess<'a> for &'a Path {
 /// It can be converted into a LanguageType (e.g. identify which language it belongs to).
 /// The name of the file is typically its path, but this might be logical in case it's part of an
 /// archive (tar, zip, ...).
-pub trait FileAccess<'a>: Copy + Send {
+pub trait FileAccess<'a>: Copy {
     /// Read the contents of the file into a string.
     fn read_to_string(self) -> io::Result<String>;
 

--- a/src/file_access.rs
+++ b/src/file_access.rs
@@ -1,0 +1,71 @@
+use std::io;
+use encoding_rs_io::DecodeReaderBytes;
+use std::fs;
+use std::path::Path;
+use std::borrow::Cow;
+
+impl<'a> FileAccess<'a> for &'a Path {
+    fn read_to_string(self) -> io::Result<String> {
+        use std::io::Read;
+
+        let f = fs::File::open(self)?;
+        let mut s = String::new();
+        DecodeReaderBytes::new(f).read_to_string(&mut s)?;
+        Ok(s)
+    }
+
+    fn read_first_line(self) -> io::Result<String> {
+        use std::io::{BufReader, BufRead};
+
+        let file = fs::File::open(self)?;
+        let mut buf = BufReader::new(file);
+        let mut line = String::new();
+        let _ = buf.read_line(&mut line);
+
+        Ok(line)
+    }
+
+    fn name(self) -> Cow<'a, str> {
+        self.to_string_lossy()
+    }
+
+    fn file_name(self) -> Option<Cow<'a, str>> {
+        match self.file_name() {
+            Some(filename_os) => {
+                Some(Cow::from(filename_os.to_string_lossy().to_lowercase()))
+            },
+            None => None
+        }
+    }
+
+    fn extension(self) -> Option<Cow<'a, str>> {
+        match self.extension() {
+            Some(extension_os) => {
+                Some(Cow::from(extension_os.to_string_lossy().to_lowercase()))
+            },
+            None => None
+        }
+    }
+}
+
+/// Trait to access files for analysis.
+///
+/// It can be converted into a LanguageType (e.g. identify which language it belongs to).
+/// The name of the file is typically its path, but this might be logical in case it's part of an
+/// archive (tar, zip, ...).
+pub trait FileAccess<'a>: Copy + Send {
+    /// Read the contents of the file into a string.
+    fn read_to_string(self) -> io::Result<String>;
+
+    /// Read the first line of the file into a string.
+    fn read_first_line(self) -> io::Result<String>;
+
+    /// Get the name of the file object.
+    fn name(self) -> Cow<'a, str>;
+
+    /// Access the file name, if available.
+    fn file_name(self) -> Option<Cow<'a, str>>;
+
+    /// Access the extension of the file, if available.
+    fn extension(self) -> Option<Cow<'a, str>>;
+}

--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -98,7 +98,7 @@ impl Languages {
         types: Option<Vec<LanguageType>>
     )
         where I: IntoIterator<Item = F>,
-              F: FileAccess<'a>,
+              F: Send + FileAccess<'a>,
     {
         utils::fs::get_all_file_accesses(files, &mut self.inner, types);
         self.inner.par_iter_mut().for_each(|(_, l)| l.total());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,9 @@ mod utils;
 mod language;
 mod stats;
 mod sort;
+mod file_access;
 
+pub use file_access::FileAccess;
 pub use language::{LanguageType, Languages, Language};
 pub use stats::Stats;
 pub use sort::Sort;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::path::PathBuf;
 
 /// A struct representing the statistics of a file.
 #[cfg_attr(feature = "io", derive(Deserialize, Serialize))]
@@ -15,12 +14,12 @@ pub struct Stats {
     /// Total number of lines within the file.
     pub lines: usize,
     /// File name.
-    pub name: PathBuf,
+    pub name: String,
 }
 
 impl Stats {
     /// Create a new `Stats` from a `ignore::DirEntry`.
-    pub fn new(name: PathBuf) -> Self {
+    pub fn new(name: String) -> Self {
         Stats {
             blanks: 0,
             code: 0,
@@ -55,18 +54,17 @@ macro_rules! display_stats {
 
 impl fmt::Display for Stats {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let name = self.name.to_string_lossy();
-        let name_length = name.len();
+        let name_length = self.name.len();
 
         let max_len = f.width().unwrap_or(25);
 
         if name_length <= max_len {
-            display_stats!(f, self, name, max_len)
+            display_stats!(f, self, self.name, max_len)
         } else {
             let mut formatted = String::from("|");
             // Add 1 to the index to account for the '|' we add to the output string
-            let from = find_char_boundary(&name, name_length + 1 - max_len);
-            formatted.push_str(&name[from..]);
+            let from = find_char_boundary(&self.name, name_length + 1 - max_len);
+            formatted.push_str(&self.name[from..]);
             display_stats!(f, self, formatted, max_len)
         }
     }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -84,7 +84,7 @@ pub fn get_all_file_accesses<'a, I: 'a, F>(
     types: Option<Vec<LanguageType>>,
 ) where
     I: IntoIterator<Item = F>,
-    F: FileAccess<'a>,
+    F: Send + FileAccess<'a>,
 {
     let types: Option<&[LanguageType]> = types.as_ref().map(|v| &**v);
 


### PR DESCRIPTION
This pushes the abstractions available to provide files for analysis down a bit, and exposes a refactored, lower-level version of `get_statistics` that allows you to provide an iterator of `FileAccess` objects for analysis.

This allows you to analyze non-filesystem like things, like tar and zip archives. Or in-memory collections of files by building an implementation of `FileAccess`.

A simple example would look something like (warning: not tested):

```rust
use std::io;

struct FakeFile {
    name: String,
    content: String,
}

impl<'a> FileAccess<'a> for &'a FakeFile {
    fn read_to_string(self) -> io::Result<String> {
        Ok(self.content.clone())
    }

    fn read_first_line(self) -> io::Result<String> {
        let line = self.content.split("\n").next().map(|s| s.to_string()).unwrap_or_else(|| self.content.to_string());
        Ok(line)
    }

    fn name(self) -> Cow<'a, str> {
        Cow::from(&self.name)
    }

    fn file_name(self) -> Option<Cow<'a, str>> {
        Some(self.name.rsplit("/").next().map(Cow::from).unwrap_or_else(|| Cow::from(&self.name)))
    }

    fn extension(self) -> Option<Cow<'a, str>> {
        match self.file_name() {
            Some(Cow::Borrowed(n)) => n.rsplit(".").next().map(Cow::from),
            Some(Cow::Owned(n)) => n.rsplit(".").next().map(|s| s.to_string()).map(Cow::from),
            None => None,
        }
    }
}
```