### PR TITLE
Introduce `Bytes` to support processing of non-UTF-8 files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,14 +149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs_io"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "encoding_rs 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,13 +675,14 @@ name = "tokei"
 version = "8.0.1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding_rs_io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -832,7 +825,6 @@ dependencies = [
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum encoding_rs 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "065f4d0c826fdaef059ac45487169d918558e3cf86c9d89f6e81cf52369126e5"
-"checksum encoding_rs_io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "098f6a0ab73a9ba256b71344dc82c6d7e252736ad9db7f4e35345f3a1f8713f5"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 
 [dependencies]
 clap = "2"
+encoding_rs = "0.8"
 ignore = "0.4"
 log = "0.4"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ serde_json = "1"
 
 [dependencies]
 clap = "2"
-encoding_rs_io = "0.1"
 ignore = "0.4"
 log = "0.4"
 rayon = "1"
 term_size = "0.3.1"
+memchr = "2"
 
 [dependencies.env_logger]
 features = []

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -24,6 +24,10 @@ impl LanguageType {
             Err(e) => return Err((e, path)),
         };
 
+        if bytes::is_binary(&text) {
+            return Err((io::Error::new(io::ErrorKind::Other, "binary file"), path));
+        }
+
         let text = match bytes::decode(&text).map_err(|e| io::Error::new(io::ErrorKind::Other, e)) {
             Ok(text) => text,
             Err(e) => return Err((e, path)),
@@ -46,6 +50,10 @@ impl LanguageType {
 
     /// Parses the text provided. Returning `Stats` on success.
     pub fn parse_from_bytes(self, path: PathBuf, text: &[u8]) -> Result<Stats, io::Error> {
+        if bytes::is_binary(&text) {
+            return Err(io::Error::new(io::ErrorKind::Other, "binary file"));
+        }
+
         let text = bytes::decode(text).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         Ok(self.parse_from_bytes_checked(path, Bytes::new(&text)))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 
 #[macro_use]
 extern crate log;
+extern crate encoding_rs;
 extern crate ignore;
 extern crate rayon;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ extern crate log;
 extern crate encoding_rs;
 extern crate ignore;
 extern crate rayon;
+extern crate memchr;
 
 #[cfg(feature = "io")]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@
 
 #[macro_use]
 extern crate log;
-extern crate encoding_rs_io;
 extern crate ignore;
 extern crate rayon;
 

--- a/src/utils/bytes.rs
+++ b/src/utils/bytes.rs
@@ -1,0 +1,168 @@
+use std::fmt;
+use std::vec;
+
+#[derive(Clone, Copy)]
+pub struct Bytes<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> Bytes<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes
+        }
+    }
+
+    /// Get the length of the bytes contained.
+    pub fn len(self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Treat as a bytes slice.
+    pub fn as_bytes(self) -> &'a [u8] {
+        self.bytes
+    }
+
+    /// Iterate over the bytes as chars.
+    pub fn utf8_chars_lossy(self) -> Utf8CharsLossy {
+        // NB: if core::lossy was available we could do this as a zero copy.
+        // right now, this is the easiest approach.
+        let it = String::from_utf8_lossy(&self.bytes)
+            .chars()
+            .collect::<Vec<char>>().into_iter();
+
+        Utf8CharsLossy {
+            it
+        }
+    }
+
+    /// Remove leading and trailing whitespace.
+    ///
+    /// Whitespace is identified by using `char::is_whitespace` on the char equivalent of a byte
+    /// treated as ascii.
+    pub fn trim(self) -> Bytes<'a> {
+        let mut b = self.bytes;
+
+        while b.len() > 0 && char::is_whitespace(b[0] as char) {
+            b = &b[1..];
+        }
+
+        while b.len() > 0 && char::is_whitespace(b[b.len() - 1] as char) {
+            b = &b[..(b.len() - 1)];
+        }
+
+        Bytes::new(b)
+    }
+
+    /// Get an iterator over all lines.
+    pub fn lines(self) -> Lines<'a> {
+        Lines {
+            buf: self.bytes,
+        }
+    }
+
+    /// Check if the given byte is contained.
+    pub fn contains(self, needle: &[u8]) -> bool {
+        self.bytes.windows(needle.len()).any(|w| w == needle)
+    }
+
+    /// Check if bytes array starts with the given value.
+    pub fn starts_with(self, needle: &[u8]) -> bool {
+        self.bytes.starts_with(needle)
+    }
+}
+
+impl<'a> fmt::Display for Bytes<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        String::from_utf8_lossy(self.bytes).fmt(fmt)
+    }
+}
+
+/// Iterator over UTF-8 characters, replacing non-legal sequences with the unicode replacement
+/// character (U+FFFD).
+#[derive(Clone)]
+pub struct Utf8CharsLossy {
+    it: vec::IntoIter<char>,
+}
+
+impl Iterator for Utf8CharsLossy {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.it.next()
+    }
+}
+
+#[derive(Clone)]
+pub struct Lines<'a> {
+    buf: &'a [u8],
+}
+
+const NL: u8 = b'\n';
+const CR: u8 = b'\r';
+
+impl<'a> Iterator for Lines<'a> {
+    type Item = Bytes<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use std::mem;
+
+        if let Some(mut idx) = memchr::memchr2(NL, CR, self.buf) {
+            let o = &self.buf[..idx];
+
+            if self.buf[idx] == NL && self.buf.get(idx + 1).map(|c| *c == CR).unwrap_or(false) {
+                idx += 1;
+            }
+
+            self.buf = &self.buf[idx + 1..];
+            return Some(Bytes::new(o));
+        }
+
+        if !self.buf.is_empty() {
+            return Some(Bytes::new(mem::replace(&mut self.buf, &[])));
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Bytes;
+
+    #[test]
+    fn test_lines() {
+        assert_eq!(5, Bytes::new(b"foo\nbar\n\rbaz\r\rtail").lines().count());
+    }
+
+    #[test]
+    fn test_utf8_chars_lossy() {
+        assert_eq!(
+            vec!['a', 'b', 'c', 'd'],
+            Bytes::new(b"abcd").utf8_chars_lossy().collect::<Vec<_>>()
+        );
+
+        // Non-UTF-8 sequences use replacement character.
+        assert_eq!(
+            vec!['\u{FFFD}'],
+            Bytes::new(b"\x8f").utf8_chars_lossy().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_trim() {
+        assert_eq!(b"foo", Bytes::new(b"    foo ").trim().as_bytes());
+    }
+
+    #[test]
+    fn test_contains() {
+        assert!(!Bytes::new(b"foobar").contains(b"blarg"));
+        assert!(Bytes::new(b"foobar").contains(b"oob"));
+    }
+
+    #[test]
+    fn test_starts_with() {
+        assert!(!Bytes::new(b"foobar").contains(b"baz"));
+        assert!(Bytes::new(b"foobar").contains(b"bar"));
+    }
+}

--- a/src/utils/bytes.rs
+++ b/src/utils/bytes.rs
@@ -4,6 +4,9 @@ use std::borrow::Cow;
 use std::error;
 
 use encoding_rs::Encoding;
+use memchr;
+
+const FIRST_FEW_BYTES: usize = 8000;
 
 #[derive(Debug)]
 pub enum DecodingError {
@@ -20,6 +23,15 @@ impl fmt::Display for DecodingError {
             DecodingError::InvalidBom => write!(fmt, "invalid bom"),
         }
     }
+}
+
+/// Test if file is a binary file by checking if any of `FIRST_FEW_BYTES` first bytes are null
+/// bytes (`0x00`).
+pub fn is_binary(bytes: &[u8]) -> bool {
+    // This mimics the git test that does the same from here:
+    // https://github.com/git/git/blob/2d3b1c576c85b7f5db1f418907af00ab88e0c303/xdiff-interface.c#L202
+    let end = usize::min(FIRST_FEW_BYTES, bytes.len());
+    memchr::memchr(0u8, &bytes[..end]).is_some()
 }
 
 /// Do your best to try and construct a Bytes instance while performing as much detection as

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 #[macro_use]
 mod macros;
 pub mod fs;
+pub mod bytes;


### PR DESCRIPTION
I was trying to use tokei to analyze older versions of the Linux kernel and noticed that it had issues with files containing comments which were encoded in iso-8859-1.

Because `DecodeReaderBytes` wasn't actually configured to use any encoding it fell back to using UTF-8, unless a BOM was present. BOMs are exceedingly rare when dealing with code files in my experience, but it's still something that we should re-incorporate here before merging to maintain the old behavior. ~~My suggestion would be to perform an explicit check of the two first bytes in the stream~~  (see TODO).

Unfortunately file encodings tend to be determined by build systems rather than the files themselves. But we can do other things like look for vim comments (e.g. `# vim: set fileencoding=`).

While reading through the code, I noticed that the analysis performed by tokei didn't use a ton of string APIs, so I built the `Bytes` abstraction to handle all the cases that were needed to operate directly on top of a `&[u8]` slice.

Any char inspection that we do now tries to decode a line using a method called `utf8_chars_lossy()`, which replaces any illegal utf-8 sequences with a replacement character `U+FFFD`.

#### TODO

- [x] Check BOM.
- [x] Test for binary files
  * this was done before because DecodeReaderBytes always attempted to decode at least as UTF-8.