### PR TITLE
Add support for ROS message files

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1290,6 +1290,12 @@
                 "cshtml"
             ]
         },
+        "ROSMsg":{
+            "base":"c",
+            "extensions":[
+                "msg"
+            ],
+        },    
         "Ruby":{
             "line_comment":[
                 "#"

--- a/tests/data/sample.msg
+++ b/tests/data/sample.msg
@@ -1,0 +1,3 @@
+float32 r
+int32 g
+char c


### PR DESCRIPTION
Identify the message file format used in the popular open-source Robot Operating System. (http://wiki.ros.org/msg).