### PR TITLE
Use box drawing characters if the charset is set to UTF8

### DIFF
--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -66,13 +66,13 @@ pub fn print_header<W: Write>(sink: &mut W, row: &str, columns: usize)
     writeln!(sink, "{}", row)
 }
 
-pub fn print_results<'a, I, W>(sink: &mut W, row: &str, languages: I, list_files: bool)
+pub fn print_results<'a, I, W>(sink: &mut W, row: &str, columns: usize, languages: I, list_files: bool)
     -> io::Result<()>
     where I: Iterator<Item = (&'a LanguageType, &'a Language)>,
           W: Write,
 {
-    let path_len = row.len() - NO_LANG_ROW_LEN_NO_SPACES;
-    let lang_section_len = row.len();
+    let path_len = columns - NO_LANG_ROW_LEN_NO_SPACES;
+    let lang_section_len = columns;
     for (name, language) in languages.filter(isnt_empty) {
         print_language(sink, lang_section_len, language, name.name())?;
 
@@ -117,4 +117,49 @@ pub fn print_language<W>(sink: &mut W,
 
 pub fn print_inaccuracy_warning<W>(sink: &mut W) -> io::Result<()> where W: Write {
     writeln!(sink, "Note: results can be inaccurate for languages marked with '{}'", IDENT_INACCURATE)
+}
+
+// This is for a best efforts approach where we use box drawing characters
+// for the separator lines, but only if we can easily determine that
+// the terminal encoding is set to UTF8. We use the POSIX environment variables for that.
+//
+// The environment variables are not set by default under windows except in posix-y
+// environments like WSL, cygwin, MSYS2.
+// Unicode is badly supported in cmd.exe and powershell and not activated by default
+// so we just fall back on ASCII there without checking the so called code page.
+//
+// The variables are assumed to follow XGP syntax:
+// `language[_territory[.codeset]][@modifier]`
+// https://www.gnu.org/software/libc/manual/html_node/Locale-Names.html
+pub fn locale_requests_utf8() -> bool {
+    // LC_ALL overrides LC_CTYPE which overrides LANG
+    // LC_CTYPE is the locale category used for the same purpose in the `tree` utility
+    let env_variables = ["LC_ALL", "LC_CTYPE", "LANG"];
+    let env = env_variables.iter()
+        .map(|&env| std::env::var(env))
+        .find(|env|
+            // filter out unset and empty variables
+            env != &Err(std::env::VarError::NotPresent)
+                && env != &Ok("".to_owned())
+        );
+
+    let lang = match env {
+        // some variable is set and contains a valid unicode string
+        Some(Ok(lang)) => lang,
+        _ => return false,
+    };
+
+    // either a path or invalid
+    // paths are rare, so we don't support them for simplicity and fall back to ascii
+    if lang.contains('/') {
+        return false;
+    }
+    // get the text between the first '.' and the first '@' (if it exists)
+    // that should be the codeset
+    let rest = match lang.split('.').nth(1) {
+        Some(rest) => rest,
+        None => return false,
+    };
+    let codeset = rest.split('@').next().unwrap();
+    codeset.eq_ignore_ascii_case("UTF-8") || codeset.eq_ignore_ascii_case("utf8")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,8 @@ fn main() -> Result<(), Box<Error>> {
     });
 
 
-    let row = "-".repeat(columns);
+    let line_char = if locale_requests_utf8() { "─" } else { "-" };
+    let row = line_char.repeat(columns);
 
     let mut stdout = io::BufWriter::new(io::stdout());
 
@@ -84,9 +85,9 @@ fn main() -> Result<(), Box<Error>> {
             Sort::Lines => languages.sort_by(|a, b| b.1.lines.cmp(&a.1.lines)),
         }
 
-        print_results(&mut stdout, &row, languages.into_iter(), cli.files)?
+        print_results(&mut stdout, &row, columns, languages.into_iter(), cli.files)?
     } else  {
-        print_results(&mut stdout, &row, languages.iter(), cli.files)?
+        print_results(&mut stdout, &row, columns, languages.iter(), cli.files)?
     }
 
     // If we're listing files there's already a trailing row so we don't want an


### PR DESCRIPTION
Implements #249

As described in the issue, this is a best efforts basis for POSIXy systems only. It checks if the codeset in `$LC_CTYPE` is set to UTF8 which is the same thing `tree` does. `LC_CTYPE` can be overriden by `LC_ALL` and falls back to `LANG` and so does this code.
While this code may be useful for someone else, I think it's not feature-complete enough for its own crate.

I've tested this under ubuntu 18.04, windows 7 (cmd, powershell and git bash). Ytain ran it on mac os where it also worked.