### PR TITLE
add .tpp extension to C++

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -338,7 +338,8 @@
                 "cpp",
                 "cxx",
                 "c++",
-                "pcc"
+                "pcc",
+                "tpp"
             ]
         },
         "CppHeader":{


### PR DESCRIPTION
`.tpp` is [frequently](https://github.com/search?utf8=%E2%9C%93&q=tpp+extension%3Atpp&type=Code&ref=advsearch&l=&l=) used for C++ header files which actually contain implementation details (e.g. due to templates or inlining).

Thanks for this useful tool!