### PR TITLE
Fix panic when columns < NO_LANG_HEADER_ROW_LEN

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,16 +47,18 @@ fn main() -> Result<(), Box<Error>> {
         process::exit(0);
     }
 
-    let columns = cli.columns.or(config.columns).unwrap_or_else(|| {
-        if cli.files {
-            term_size::dimensions().map_or(FALLBACK_ROW_LEN, |(w, _)| {
-                w.max(FALLBACK_ROW_LEN)
-            })
-        } else {
-            FALLBACK_ROW_LEN
-        }
-    });
-
+    let columns = cli
+        .columns
+        .or(config.columns)
+        .or_else(|| {
+            if cli.files {
+                term_size::dimensions().map(|(w, _)| w)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(FALLBACK_ROW_LEN)
+        .max(FALLBACK_ROW_LEN);
 
     let row = "-".repeat(columns);
 


### PR DESCRIPTION
Thank you for making Tokei! This fixes the following panic by ensuring that `columns` is always wide enough to print the header row:

    $ cargo run -- --columns=66
    thread 'main' panicked at 'attempt to subtract with overflow',
    src/cli_utils.rs:64:17

