### PR TITLE
fix link to nix/nixos installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is tokei running on its own directory
         - [Fedora](#fedora)
         - [FreeBSD](#freebsd)
         - [Homebrew](#homebrew)
-        - [Nix/NixOS](#nix/nixos)
+        - [Nix/NixOS](#nixnixos)
     - [Manual](#manual)
 - [How to use Tokei](#how-to-use-tokei)
 - [Options](#options)


### PR DESCRIPTION
Current link to Nix/NixOS installation instruction doesn't scroll down on both Firefox and Chrome. This PR fixes it.