### PR TITLE
Add MoonScript to Languages

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1045,6 +1045,18 @@
             "extensions": ["def"],
             "line_comment": [";"]
         },
+        "MoonScript":{
+            "line_comment":[
+                "--"
+            ],
+            "quotes":[
+                ["\\\"", "\\\""],
+                ["'", "'"]
+            ],
+            "extensions":[
+                "moon"
+            ]
+        },
         "Meson":{
             "line_comment":[
                 "#"


### PR DESCRIPTION
A language that compiles to Lua, ref: https://moonscript.org/. Does not have multi-line comments.