### PR TITLE
Added support for HolyC (language of TempleOS)

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -751,6 +751,13 @@
                 "hlsl"
             ]
         },
+        "HolyC":{
+            "base":"c",
+            "extensions":[
+                "HC",
+                "hc"
+            ]
+        },
         "Html":{
             "name":"HTML",
             "base":"html",


### PR DESCRIPTION
Can't just skip over the implementation language of God's Holy Temple as written by Terry A. Davis, now can you?