### PR TITLE
Add language support for Lex and Yacc

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -708,12 +708,6 @@
                 "gvy"
             ]
         },
-        "Happy":{
-            "extensions":[
-                "y",
-                "ly"
-            ]
-        },
         "Handlebars":{
             "multi_line":[
                 ["<!--", "-->"],
@@ -945,6 +939,14 @@
             "extensions":[
                 "kt",
                 "kts"
+            ]
+        },
+        "Lex":{
+            "name":"LEX",
+            "base":"c",
+            "extensions":[
+                "l",
+                "lpp"
             ]
         },
         "Lean":{
@@ -1991,6 +1993,14 @@
             "extensions":[
                 "xtend"
 
+            ]
+        },
+        "Yacc":{
+            "name":"YACC",
+            "base":"c",
+            "extensions":[
+                "y",
+                "ypp"
             ]
         },
         "Yaml":{


### PR DESCRIPTION
The file extension 'y' is now associated to Yacc's source files and no
longer to Happy which I have no idea what language it is.

Signed-off-by: Li Peng <lipeng31@gmail.com>