### PR TITLE
Add FreeMarker language support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -629,6 +629,16 @@
                 "f95"
             ]
         },
+        "FreeMarker":{
+            "multi_line":[
+                ["<#--", "-->"]
+            ],
+            "extensions":[
+                "ftl",
+                "ftlh",
+                "ftlx"
+            ]
+        },
         "FSharp":{
             "name":"F#",
             "line_comment":[

--- a/tests/data/ftl.ftl
+++ b/tests/data/ftl.ftl
@@ -1,0 +1,10 @@
+<#-- 9 lines 5 code 2 comments 2 blanks -->
+<#ftl output_format="plainText"/>
+
+<#-- Define the print macro -->
+<#macro print text>
+${text}
+</#macro>
+
+<#-- Print "Hello world" -->
+<@print "Hello world"/>

--- a/tests/data/ftl.ftl
+++ b/tests/data/ftl.ftl
@@ -1,4 +1,4 @@
-<#-- 9 lines 5 code 2 comments 2 blanks -->
+<#-- 10 lines 5 code 3 comments 2 blanks -->
 <#ftl output_format="plainText"/>
 
 <#-- Define the print macro -->


### PR DESCRIPTION
Adds support for the Apache FreeMarker template language with `.ftl`, `.ftlh`, and `.ftlx` as associated file extensions.