### PR TITLE
fix contributor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ please make your issues, and pull requests there.
 ## Copyright and License
 (C) Copyright 2015 by Aaron Power and contributors
 
-See CONTRIBUTORS.md for a full list of contributors.
+See [the graph](https://github.com/XAMPPRocky/tokei/graphs/contributors) for a full list of contributors.
 
 Tokei is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
 


### PR DESCRIPTION
This is the "easy" way to attribute contributors.
Another thought I had was to automatically generate a `CONTRIBUTING.md` if we wanted to embed contributor data in the repository. Overkill IMHO 😄 