### PR TITLE
.pyw is a valid Python extension

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1392,7 +1392,8 @@
                 "python3"
             ],
             "extensions":[
-                "py"
+                "py",
+                "pyw"
             ]
         },
         "Qcl":{


### PR DESCRIPTION
I added `pyw` since it is a valid Python extension.
I can only find two references to this fact in the official python docs (search for "pyw" in these):
https://www.python.org/dev/peps/pep-0397/
https://www.python.org/download/releases/2.4.1/notes/