### PR TITLE
Optionally format numbers with thousands separator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -504,6 +512,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +901,7 @@ dependencies = [
  "ignore 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-format 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1019,6 +1042,7 @@ dependencies = [
 "checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+"checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
@@ -1079,6 +1103,8 @@ dependencies = [
 "checksum memchr 2.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+"checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+"checksum num-format 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ term_size = "0.3.1"
 toml = "0.5.6"
 grep-searcher = "0.1.6"
 crossbeam-channel = "0.4.2"
+num-format = "0.4.0"
 
 [dependencies.env_logger]
 features = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate log;
 mod cli;
 mod cli_utils;
 mod input;
+mod output;
 
 use std::{
     error::Error,
@@ -55,6 +56,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .unwrap_or(FALLBACK_ROW_LEN)
         .max(FALLBACK_ROW_LEN);
 
+    let num_format = &cli.num_format;
+
     languages.get_statistics(&input, &cli.ignored_directories(), &config);
 
     if let Some(format) = cli.output {
@@ -87,9 +90,15 @@ fn main() -> Result<(), Box<dyn Error>> {
             Sort::Lines => languages.sort_by(|a, b| b.1.lines.cmp(&a.1.lines)),
         }
 
-        print_results(&mut stdout, &row, languages.into_iter(), cli.files)?
+        print_results(
+            &mut stdout,
+            &row,
+            languages.into_iter(),
+            cli.files,
+            num_format,
+        )?
     } else {
-        print_results(&mut stdout, &row, languages.iter(), cli.files)?
+        print_results(&mut stdout, &row, languages.iter(), cli.files, num_format)?
     }
 
     // If we're listing files there's already a trailing row so we don't want an
@@ -104,7 +113,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         total += language;
     }
 
-    print_language(&mut stdout, columns, &total, "Total")?;
+    print_language(&mut stdout, columns, &total, "Total", num_format)?;
     writeln!(stdout, "{}", row)?;
 
     Ok(())

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,42 @@
+use num_format::{CustomFormat, Grouping};
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum NumberFormatStyle {
+    // 1234 (Default)
+    Plain,
+    // 1,234
+    Commas,
+    // 1.234
+    Dots,
+}
+
+impl NumberFormatStyle {
+    pub fn all() -> &'static [&'static str] {
+        &["plain", "commas", "dots"]
+    }
+
+    pub fn from_str(input: &str) -> Option<NumberFormatStyle> {
+        Some(match input {
+            "plain" => NumberFormatStyle::Plain,
+            "commas" => NumberFormatStyle::Commas,
+            "dots" => NumberFormatStyle::Dots,
+            _ => return None,
+        })
+    }
+
+    pub fn get_format(self) -> CustomFormat {
+        CustomFormat::builder()
+            .grouping(Grouping::Standard)
+            .separator(self.separator())
+            .build()
+            .unwrap_or_else(|_| panic!("Could not construct format from variant {:?}", self))
+    }
+
+    fn separator(self) -> &'static str {
+        match self {
+            NumberFormatStyle::Plain => "",
+            NumberFormatStyle::Commas => ",",
+            NumberFormatStyle::Dots => ".",
+        }
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,4 @@
-use std::{fmt, path::PathBuf};
+use std::path::PathBuf;
 
 /// A struct representing the statistics of a file.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -27,49 +27,6 @@ impl Stats {
             comments: 0,
             lines: 0,
             name,
-        }
-    }
-}
-
-fn find_char_boundary(s: &str, index: usize) -> usize {
-    for i in 0..4 {
-        if s.is_char_boundary(index + i) {
-            return index + i;
-        }
-    }
-    unreachable!();
-}
-
-macro_rules! display_stats {
-    ($f:expr, $this:expr, $name:expr, $max:expr) => {
-        write!(
-            $f,
-            " {: <max$} {:>12} {:>12} {:>12} {:>12}",
-            $name,
-            $this.lines,
-            $this.code,
-            $this.comments,
-            $this.blanks,
-            max = $max
-        )
-    };
-}
-
-impl fmt::Display for Stats {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let name = self.name.to_string_lossy();
-        let name_length = name.len();
-
-        let max_len = f.width().unwrap_or(25);
-
-        if name_length <= max_len {
-            display_stats!(f, self, name, max_len)
-        } else {
-            let mut formatted = String::from("|");
-            // Add 1 to the index to account for the '|' we add to the output string
-            let from = find_char_boundary(&name, name_length + 1 - max_len);
-            formatted.push_str(&name[from..]);
-            display_stats!(f, self, formatted, max_len)
         }
     }
 }


### PR DESCRIPTION
Closes #256.

Add a new option, `-n`/`--num-format` to specify whether the output should
separated by commas, dots, or nothing (plain).

This adds a new import, `num-format`, to perform the formatting. This adds a
total of three new dependencies: `arrayvec` version 0.4, `ndodrop`, and
`num-format`.

---

If we like the way this looks, I can add a configuration option. I would assume that most users would prefer to put their preferred value in the configuration option so they don't have to specify it every time.