### PR TITLE
Updated README.md to reflect support languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,96 +266,103 @@ request. Languages are defined in [`languages.json`](./languages.json), and you 
 read how to add and test your language in our [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ```
-ABAP
+Abap
 ActionScript
 Ada
 Agda
 Alex
-ASP
-ASP.NET
+Asn1
+Asp
+AspNet
 Assembly
 AssemblyGAS
-AutoHotKey
 Autoconf
+AutoHotKey
 Automake
-BASH
+Bash
 Batch
 BrightScript
 C
-C Header
-CMake
-C#
-C Shell
 Cabal
 Cassius
 Ceylon
+CHeader
 Clojure
 ClojureC
 ClojureScript
-COBOL
+CMake
+Cobol
 CoffeeScript
 Cogent
 ColdFusion
-ColdFusion CFScript
+ColdFusionScript
 Coq
-C++
-C++ Header
+Cpp
+CppHeader
 Crystal
-CSS
+CSharp
+CShell
+Css
 D
 Dart
-Device Tree
+DeviceTree
 Dockerfile
-.NET Resource
-Dream Maker
+DotNetResource
+DreamMaker
+Dust
 Edn
-Emacs Lisp
+Elisp
 Elixir
 Elm
 Elvish
-Emacs Dev Env
+EmacsDevEnv
+Emojicode
 Erlang
 FEN
-F#
 Fish
+FlatBuffers
 Forth
-FORTRAN Legacy
-FORTRAN Modern
-F*
-GDB Script
-GDScript
-Gherkin (Cucumber)
-GLSL
+FortranLegacy
+FortranModern
+FreeMarker
+FSharp
+Fstar
+GDB
+GdScript
+Gherkin
+Glsl
 Go
+Graphql
 Groovy
 Hamlet
 Handlebars
 Happy
 Haskell
 Haxe
-HCL
-HEX
-HLSL
+Hcl
+Hex
+Hlsl
 HolyC
-HTML
+Html
 Idris
-INI
-Intel HEX
+Ini
+IntelHex
 Isabelle
-JAI
+Jai
 Java
 JavaScript
-JSON
-JSX
+Json
+Jsx
 Julia
 Julius
-Kakoune script
+KakouneScript
 Kotlin
 Lean
-LESS
-LD Script
+Less
+LinkerScript
 Liquid
 Lisp
+LLVM
 Logtalk
 Lua
 Lucius
@@ -364,86 +371,97 @@ Makefile
 Markdown
 Meson
 Mint
-Module-Definition
-MSBuild
+ModuleDef
+MoonScript
+MsBuild
 Mustache
 Nim
 Nix
-Not Quite Perl
+NotQuitePerl
+ObjectiveC
+ObjectiveCpp
 OCaml
-Objective-C
-Objective-C++
+Odin
 Org
 Oz
-PSL Assertion
 Pascal
 Perl
 Perl6
-PHP
+Pest
+Php
 Polly
+Pony
+PostCss
 PowerShell
 Processing
 Prolog
-Protocol Buffers
+Protobuf
+PSL
 PureScript
 Python
-QCL
-QML
+Qcl
+Qml
 R
 Racket
 Rakefile
 Razor
 ReStructuredText
+RON
+RPMSpecfile
 Ruby
-Ruby HTML
+RubyHtml
 Rust
-SRecode Template
 Sass
 Scala
 Scheme
 Scons
-Shell
-Standard ML (SML)
+Sh
+Sml
 Solidity
-Specman e
-Spice Netlist
-SQL
-SVG
+SpecmanE
+Spice
+Sql
+SRecode
+Stratego
+Svg
 Swift
-SWIG
+Swig
 SystemVerilog
-TCL
-TeX
-Plain Text
-TOML
+Tcl
+Tex
+Text
+Thrift
+Toml
 Twig
 TypeScript
-Unreal Markdown
-Unreal Plugin
-Unreal Project
-Unreal Script
-Unreal Shader
-Unreal Shader Header
-Ur/Web
-Ur/Web Project
+UnrealDeveloperMarkdown
+UnrealPlugin
+UnrealProject
+UnrealScript
+UnrealShader
+UnrealShaderHeader
+UrWeb
+UrWebProject
+Vala
 VB6
 VBScript
-Vala
+Velocity
 Verilog
-Verilog Args File
-VHDL
-Vim Script
-Visual Basic
-Visual Studio Project
-Visual Studio Solution
+VerilogArgsFile
+Vhdl
+VimScript
+VisualBasic
+VisualStudioProject
+VisualStudioSolution
 Vue
+WebAssembly
 Wolfram
+Xaml
+XcodeConfig
+Xml
 XSL
-XAML
-Xcode Config
-XML
 Xtend
-YAML
+Yaml
 Zig
 Zsh
 ```

--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Perl
 Perl6
 PHP
 Polly
+PowerShell
 Processing
 Prolog
 Protocol Buffers


### PR DESCRIPTION
Started by noting that PowerShell wasn't listed in the README even though it is supported.  Then looked to see what else wasn't in the README based on languages.json.  Turns out a number of languages.  To make this easier to keep up-to-date, I simply grabbed all the language names from the json and replaced the ones in the README.  Some casing  has changed, but it seems that languages.json should be the source of truth which makes keeping the README up-to-date much simpler as well.