### PR TITLE
Fix shebang language detection

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -76,7 +76,7 @@
     },
     "Sh": {
       "name": "Shell",
-      "shebang_paths": ["#!/bin/sh"],
+      "shebangs": ["#!/bin/sh"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["sh"],
@@ -84,7 +84,7 @@
     },
     "Bash": {
       "name": "BASH",
-      "shebang_paths": ["#!/bin/bash"],
+      "shebangs": ["#!/bin/bash"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["bash"],
@@ -102,7 +102,7 @@
       "extensions": ["elv"]
     },
     "Fish": {
-      "shebang_paths": ["#!/bin/fish"],
+      "shebangs": ["#!/bin/fish"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["fish"],
@@ -224,7 +224,7 @@
     },
     "CShell": {
       "name": "C Shell",
-      "shebang_paths": ["#!/bin/csh"],
+      "shebangs": ["#!/bin/csh"],
       "line_comment": ["#"],
       "env": ["csh"],
       "extensions": ["csh"]
@@ -723,7 +723,7 @@
       "extensions": ["pas", "pp"]
     },
     "Perl": {
-      "shebang_paths": ["#!/usr/bin/perl"],
+      "shebangs": ["#!/usr/bin/perl"],
       "line_comment": ["#"],
       "multi_line_comments": [["=pod", "=cut"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
@@ -1211,7 +1211,7 @@
       "extensions": ["zig"]
     },
     "Zsh": {
-      "shebang_paths": ["#!/bin/zsh"],
+      "shebangs": ["#!/bin/zsh"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["zsh"]

--- a/languages.json
+++ b/languages.json
@@ -76,6 +76,7 @@
     },
     "Sh": {
       "name": "Shell",
+      "shebang_paths": ["#!/bin/sh"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["sh"],
@@ -83,6 +84,7 @@
     },
     "Bash": {
       "name": "BASH",
+      "shebang_paths": ["#!/bin/bash"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["bash"],
@@ -100,6 +102,7 @@
       "extensions": ["elv"]
     },
     "Fish": {
+      "shebang_paths": ["#!/bin/fish"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["fish"],
@@ -221,6 +224,7 @@
     },
     "CShell": {
       "name": "C Shell",
+      "shebang_paths": ["#!/bin/csh"],
       "line_comment": ["#"],
       "env": ["csh"],
       "extensions": ["csh"]
@@ -719,6 +723,7 @@
       "extensions": ["pas", "pp"]
     },
     "Perl": {
+      "shebang_paths": ["#!/usr/bin/perl"],
       "line_comment": ["#"],
       "multi_line_comments": [["=pod", "=cut"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
@@ -1206,6 +1211,7 @@
       "extensions": ["zig"]
     },
     "Zsh": {
+      "shebang_paths": ["#!/bin/zsh"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["zsh"]

--- a/src/language/language_type.hbs.rs
+++ b/src/language/language_type.hbs.rs
@@ -530,10 +530,10 @@ pub fn get_filetype_from_shebang(file: &Path) -> Option<&'static str>
     let mut words = line.split_whitespace();
     match words.next() {
         {{#each languages}}
+        {{~#if this.shebangs}}
         {{~#each this.shebangs}}
         | Some("{{this}}")
         {{~/each}}
-        {{~#if this.shebangs}}
             => Some("{{~@key}}"),
         {{~/if}}
         {{~/each}}

--- a/src/language/language_type.hbs.rs
+++ b/src/language/language_type.hbs.rs
@@ -195,6 +195,28 @@ impl LanguageType {
         }
     }
 
+    /// Returns the shebang of a language.
+    /// ```
+    /// use tokei::LanguageType;
+    /// let lang = LanguageType::Bash;
+    /// assert_eq!(lang.shebang_paths(), &["#!/bin/bash"]);
+    /// ```
+    pub fn shebang_paths(self) -> &'static [&'static str] {
+        match self {
+            {{#each languages}}
+            {{#if this.shebang_paths}}
+                {{~@key}} =>
+                    &[
+                        {{~#each this.shebang_paths}}
+                            "{{~this}}",
+                        {{~/each}}
+                    ],
+            {{~/if}}
+            {{~/each}}
+            _ => &[],
+        }
+    }
+
     pub(crate) fn start_any_comments(self) -> &'static [&'static str] {
         match self {
             {{#each languages}}
@@ -484,9 +506,17 @@ pub fn get_filetype_from_shebang(file: &Path) -> Option<&'static str>
 
     let mut words = line.split_whitespace();
     match words.next() {
-        Some("#!/bin/sh") => Some("sh"),
-        Some("#!/bin/csh") => Some("csh"),
-        Some("#!/usr/bin/perl") => Some("pl"),
+        {{#each languages}}
+        {{~#each this.shebang_paths}}
+        Some("{{this}}")
+        {{~#unless @last}}
+        |
+        {{~/unless}}
+        {{~/each}}
+        {{~#if this.shebang_paths}}
+            => Some("{{~@key}}"),
+        {{~/if}}
+        {{~/each}}
         Some("#!/usr/bin/env") => {
             if let Some(word) = words.next() {
                 match word {

--- a/src/language/language_type.hbs.rs
+++ b/src/language/language_type.hbs.rs
@@ -454,14 +454,13 @@ impl LanguageType {
     ///
     /// ```no_run
     /// use tokei::LanguageType;
-    /// use std::path::Path;
     ///
-    /// let rust = LanguageType::from_shebang(Path::new("./main.rs"));
+    /// let rust = LanguageType::from_shebang("./main.rs");
     ///
     /// assert_eq!(rust, Some(LanguageType::Rust));
     /// ```
-    pub fn from_shebang(entry: &Path) -> Option<Self> {
-        if let Some(filetype) = get_filetype_from_shebang(&entry) {
+    pub fn from_shebang<P: AsRef<Path>>(entry: P) -> Option<Self> {
+        if let Some(filetype) = get_filetype_from_shebang(entry.as_ref()) {
             match filetype {
                 {{~#each languages}}
                     "{{~@key}}" => Some({{~@key}}),

--- a/src/language/language_type.hbs.rs
+++ b/src/language/language_type.hbs.rs
@@ -199,15 +199,15 @@ impl LanguageType {
     /// ```
     /// use tokei::LanguageType;
     /// let lang = LanguageType::Bash;
-    /// assert_eq!(lang.shebang_paths(), &["#!/bin/bash"]);
+    /// assert_eq!(lang.shebangs(), &["#!/bin/bash"]);
     /// ```
-    pub fn shebang_paths(self) -> &'static [&'static str] {
+    pub fn shebangs(self) -> &'static [&'static str] {
         match self {
             {{#each languages}}
-            {{#if this.shebang_paths}}
+            {{#if this.shebangs}}
                 {{~@key}} =>
                     &[
-                        {{~#each this.shebang_paths}}
+                        {{~#each this.shebangs}}
                             "{{~this}}",
                         {{~/each}}
                     ],
@@ -420,7 +420,7 @@ impl LanguageType {
         let extension = fsutils::get_extension(&entry);
         match extension {
             Some(extension) => LanguageType::from_file_extension(extension.as_str()),
-            None => LanguageType::from_shebang_path(&entry),
+            None => LanguageType::from_shebang(&entry),
         }
     }
 
@@ -438,7 +438,7 @@ impl LanguageType {
             {{~#each languages}}
                 {{~#if this.extensions}}
                     {{~#each this.extensions}}
-                        "{{~this}}" {{~#unless @last}} | {{~/unless}}
+                        | "{{~this}}"
                     {{~/each}}
                         => Some({{~@key}}),
                 {{~/if}}
@@ -455,11 +455,11 @@ impl LanguageType {
     /// ```no_run
     /// use tokei::LanguageType;
     ///
-    /// let rust = LanguageType::from_shebang_path("./main.rs");
+    /// let rust = LanguageType::from_shebang("./main.rs");
     ///
     /// assert_eq!(rust, Some(LanguageType::Rust));
     /// ```
-    pub fn from_shebang_path(entry: &Path) -> Option<Self> {
+    pub fn from_shebang(entry: &Path) -> Option<Self> {
         if let Some(filetype) = get_filetype_from_shebang(&entry) {
             match filetype {
                 {{~#each languages}}
@@ -530,13 +530,10 @@ pub fn get_filetype_from_shebang(file: &Path) -> Option<&'static str>
     let mut words = line.split_whitespace();
     match words.next() {
         {{#each languages}}
-        {{~#each this.shebang_paths}}
-        Some("{{this}}")
-        {{~#unless @last}}
-        |
-        {{~/unless}}
+        {{~#each this.shebangs}}
+        | Some("{{this}}")
         {{~/each}}
-        {{~#if this.shebang_paths}}
+        {{~#if this.shebangs}}
             => Some("{{~@key}}"),
         {{~/if}}
         {{~/each}}

--- a/src/language/language_type.hbs.rs
+++ b/src/language/language_type.hbs.rs
@@ -454,8 +454,9 @@ impl LanguageType {
     ///
     /// ```no_run
     /// use tokei::LanguageType;
+    /// use std::path::Path;
     ///
-    /// let rust = LanguageType::from_shebang("./main.rs");
+    /// let rust = LanguageType::from_shebang(Path::new("./main.rs"));
     ///
     /// assert_eq!(rust, Some(LanguageType::Rust));
     /// ```
@@ -548,7 +549,7 @@ pub fn get_filetype_from_shebang(file: &Path) -> Option<&'static str>
                                     |
                                 {{~/unless}}
                             {{~/each}}
-                                => Some("{{this.extensions.[0]}}"),
+                                => Some("{{@key}}"),
                         {{~/if}}
                     {{~/each}}
                     env => {

--- a/src/language/language_type.hbs.rs
+++ b/src/language/language_type.hbs.rs
@@ -419,8 +419,7 @@ impl LanguageType {
 
         let extension = fsutils::get_extension(&entry);
         let filetype = extension.as_ref()
-            .map(|s| &**s)
-            .or_else(|| get_filetype_from_shebang(&entry));
+            .map(|s| &**s);
 
         if let Some(extension) = filetype {
             /*
@@ -448,7 +447,20 @@ impl LanguageType {
                 },
             }
         } else {
-            None
+            // Check the shebang if the extension failed
+            if let Some(filetype) = get_filetype_from_shebang(&entry) {
+                match filetype {
+                    {{~#each languages}}
+                        "{{~@key}}" => Some({{~@key}}),
+                    {{~/each}}
+                    extension => {
+                        warn!("Unknown extension: {}", extension);
+                        None
+                    },
+                }
+            } else {
+                None
+            }
         }
     }
 }

--- a/src/language/language_type.hbs.rs
+++ b/src/language/language_type.hbs.rs
@@ -418,28 +418,52 @@ impl LanguageType {
         }
 
         let extension = fsutils::get_extension(&entry);
-        let filetype = extension.as_ref()
-            .map(|s| &**s);
+        match extension {
+            Some(extension) => LanguageType::from_file_extension(extension.as_str()),
+            None => LanguageType::from_shebang_path(&entry),
+        }
+    }
 
-        if let Some(extension) = filetype {
-            /*
-            if let Some(ref languages) = config.languages {
-                for (language, lang_config) in languages {
-                    if lang_config.extensions.iter().any(|e| e == extension) {
-                        return Some(*language)
-                    }
-                }
-            }
-            */
+    /// Get language from a file extension.
+    ///
+    /// ```no_run
+    /// use tokei::LanguageType;
+    ///
+    /// let rust = LanguageType::from_file_extension("rs");
+    ///
+    /// assert_eq!(rust, Some(LanguageType::Rust));
+    /// ```
+    pub fn from_file_extension(extension: &str) -> Option<Self> {
+        match extension {
+            {{~#each languages}}
+                {{~#if this.extensions}}
+                    {{~#each this.extensions}}
+                        "{{~this}}" {{~#unless @last}} | {{~/unless}}
+                    {{~/each}}
+                        => Some({{~@key}}),
+                {{~/if}}
+            {{~/each}}
+            extension => {
+                warn!("Unknown extension: {}", extension);
+                None
+            },
+        }
+    }
 
-            match extension {
+    /// Get language from a shebang. May open and read the file.
+    ///
+    /// ```no_run
+    /// use tokei::LanguageType;
+    ///
+    /// let rust = LanguageType::from_shebang_path("./main.rs");
+    ///
+    /// assert_eq!(rust, Some(LanguageType::Rust));
+    /// ```
+    pub fn from_shebang_path(entry: &Path) -> Option<Self> {
+        if let Some(filetype) = get_filetype_from_shebang(&entry) {
+            match filetype {
                 {{~#each languages}}
-                    {{~#if this.extensions}}
-                        {{~#each this.extensions}}
-                            "{{~this}}" {{~#unless @last}} | {{~/unless}}
-                        {{~/each}}
-                            => Some({{~@key}}),
-                    {{~/if}}
+                    "{{~@key}}" => Some({{~@key}}),
                 {{~/each}}
                 extension => {
                     warn!("Unknown extension: {}", extension);
@@ -447,20 +471,7 @@ impl LanguageType {
                 },
             }
         } else {
-            // Check the shebang if the extension failed
-            if let Some(filetype) = get_filetype_from_shebang(&entry) {
-                match filetype {
-                    {{~#each languages}}
-                        "{{~@key}}" => Some({{~@key}}),
-                    {{~/each}}
-                    extension => {
-                        warn!("Unknown extension: {}", extension);
-                        None
-                    },
-                }
-            } else {
-                None
-            }
+            None
         }
     }
 }


### PR DESCRIPTION
Closes #431.

Adds the `shebang_paths` property to languages.json.

Also adds `from_file_extension` and `from_shebang_path` to `LanguageType`, making `from_path` more clear.