### PR TITLE
Add support for the Pan Configuration DSL

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -715,6 +715,11 @@
       "multi_line_comments": [["/*", "*/"]],
       "extensions": ["oz"]
     },
+    "Pan": {
+      "line_comment": ["#"],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["pan", "tpl"]
+    },
     "Pascal": {
       "nested": true,
       "line_comment": ["//"],

--- a/tests/data/pan.pan
+++ b/tests/data/pan.pan
@@ -1,0 +1,21 @@
+# 21 lines 11 code 4 comments 6 blanks
+
+# Pan example code, see https://quattor-pan.readthedocs.io/en/stable/pan-book/index.html
+
+prefix "/system/aii/osinstall/ks";
+"clearpart" = append("vdb");
+"ignoredisk" = list(); # no disks to ignore
+
+prefix "/system/blockdevices";
+"physical_devs/vdb/label" = "msdos";
+"partitions/vdb1" = dict(
+    "holding_dev", "vdb",
+);
+
+"files/{/srv/elasticsearch}" = dict('size', 0);
+
+# To facilitate adding other partitions at a later stage, a
+# logical volume will be created
+"volume_groups/vg1/device_list" = append("partitions/vdb1");
+"logical_volumes" = lvs_add('vg1', dict("elasticsearch", -1));
+


### PR DESCRIPTION
Example output:

~~~~
-------------------------------------------------------------------------------
 Language            Files        Lines         Code     Comments       Blanks
-------------------------------------------------------------------------------
 BASH                    4          442          299           73           70
 Batch                  12          749          558           50          141
 CSS                     3          406          305           32           69
 HTML                    1           56           41            0           15
 JavaScript              4         1559         1052          353          154
 Markdown                7           95           95            0            0
 Pan                  8298       194446       152913        11179        30354
 Perl                   13         2077         1330          428          319
 PHP                     2           97           68           10           19
 Python                  7         1718         1203          150          365
 Shell                  18         1308          842          230          236
 Plain Text             12          928          928            0            0
 XSL                    15         7094         5540          866          688
 XML                     5          881          534          172          175
-------------------------------------------------------------------------------
 Total                8401       211856       165708        13543        32605
-------------------------------------------------------------------------------
~~~~
