### PR TITLE
Add .erb extension for "Ruby HTML"

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -920,7 +920,7 @@
       "name": "Ruby HTML",
       "multi_line_comments": [["<!--", "-->"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "extensions": ["rhtml"]
+      "extensions": ["rhtml", "erb"]
     },
     "Rust": {
       "line_comment": ["//"],

--- a/tests/data/ruby_html.erb
+++ b/tests/data/ruby_html.erb
@@ -1,0 +1,34 @@
+<!-- 34 lines 21 code 8 comments 5 blanks -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title><%= title %></title>
+  </head>
+
+  <body>
+    <nav class="navbar navbar-default navbar-fixed-top navbar-custom">
+      <%# ruby comment %>
+      <div id="modalSearch" class="modal fade" role="dialog"> </div>
+    </nav>
+
+    <!-- HTML single line Comment-->
+    <main>
+      <article>
+        <h1><%= header %></h1>
+        <p><%= text %></p>
+      </article>
+    </main>
+
+    <%= template "footer" %>
+  </body>
+
+  <!--
+          document.write("Multi-line and Code comment!");
+  //-->
+
+  <!--[if IE 8]>
+          IE Special comment
+  <![endif]-->
+</html>


### PR DESCRIPTION
The `.erb` extension has been used over `.rhtml` in Ruby on Rails for over a decade at this point.