### PR TITLE
Add language Svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Tokei ([時計](https://en.wiktionary.org/wiki/%E6%99%82%E8%A8%88))
+
 [![Mean Bean CI](https://github.com/XAMPPRocky/tokei/workflows/Mean%20Bean%20CI/badge.svg)](https://github.com/XAMPPRocky/tokei/actions?query=workflow%3A%22Mean+Bean+CI%22)
 [![crates.io](https://img.shields.io/crates/d/tokei.svg)](https://crates.io/crates/tokei)
 [![Help Wanted](https://img.shields.io/github/issues/XAMPPRocky/tokei/help%20wanted?color=green)](https://github.com/XAMPPRocky/tokei/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
@@ -8,9 +9,11 @@
 Tokei is a program that displays statistics about your code. Tokei will show the number of files, total lines within those files and code, comments, and blanks grouped by language.
 
 ### Translations
+
 - [中文](https://github.com/chinanf-boy/tokei-zh#支持的语言)
 
 ## Example
+
 ```console
 -------------------------------------------------------------------------------
  Language            Files        Lines         Code     Comments       Blanks
@@ -32,8 +35,8 @@ Tokei is a program that displays statistics about your code. Tokei will show the
 
 - [Features](#features)
 - [Installation](#installation)
-    - [Package Managers](#package-managers)
-    - [Manual](#manual)
+  - [Package Managers](#package-managers)
+  - [Manual](#manual)
 - [How to use Tokei](#how-to-use-tokei)
 - [Options](#options)
 - [Badges](#badges)
@@ -69,6 +72,7 @@ Tokei is a program that displays statistics about your code. Tokei will show the
 ## Installation
 
 ### Package Managers
+
 ```console
 # Arch Linux
 pacman -S tokei
@@ -91,11 +95,14 @@ sudo zypper install tokei
 ### Manual
 
 #### Downloading
+
 You can download prebuilt binaries in the
 [releases section](https://github.com/XAMPPRocky/tokei/releases).
 
 #### Building
+
 You can also build and install from source (requires the latest stable [Rust] compiler.)
+
 ```console
 cargo install --git https://github.com/XAMPPRocky/tokei.git
 ```
@@ -114,17 +121,20 @@ $ tokei ./foo
 ```
 
 #### Multiple folders
+
 To have tokei report on multiple folders in the same call simply add a comma,
 or a space followed by another path.
 
 ```shell
 $ tokei ./foo ./bar ./baz
 ```
+
 ```shell
 $ tokei ./foo, ./bar, ./baz
 ```
 
 #### Excluding folders
+
 Tokei will respect all `.gitignore` and `.ignore` files, and you can use
 the `--exclude` option to exclude any additional files. The `--exclude` flag has
 the same semantics as `.gitignore`.
@@ -134,6 +144,7 @@ $ tokei ./foo --exclude *.rs
 ```
 
 #### Sorting output
+
 By default tokei sorts alphabetically by language name, however using `--sort`
 tokei can also sort by any of the columns.
 
@@ -144,6 +155,7 @@ $ tokei ./foo --sort code
 ```
 
 #### Outputting file statistics
+
 By default tokei only outputs the total of the languages, and using `--files`
 flag tokei can also output individual file statistics.
 
@@ -152,6 +164,7 @@ $ tokei ./foo --files
 ```
 
 #### Outputting into different formats
+
 Tokei normally outputs into a nice human readable format designed for terminals.
 There is also using the `--output` option various other formats that are more
 useful for bringing the data into another program.
@@ -177,6 +190,7 @@ tokei with the features flag.
 ```
 
 **Currently supported formats**
+
 - JSON `--output json`
 - YAML `--output yaml`
 - TOML `--output toml`
@@ -187,6 +201,7 @@ $ tokei ./foo --output json
 ```
 
 #### Reading in stored formats
+
 Tokei can also take in the outputted formats added in the previous results to it's
 current run. Tokei can take either a path to a file, the format passed in as a
 value to the option, or from stdin.
@@ -230,6 +245,7 @@ ARGS:
 ```
 
 ## Badges
+
 Tokei has support for badges. For example
 [![](https://tokei.rs/b1/github/XAMPPRocky/tokei)](https://github.com/XAMPPRocky/tokei).
 
@@ -255,6 +271,7 @@ Example show total lines:
 The server code hosted on tokei.rs is in [XAMPPRocky/tokei_rs](https://github.com/XAMPPRocky/tokei_rs)
 
 ## Plugins
+
 Thanks to contributors tokei is now available as a plugin for some text editors.
 
 - [Vim](https://github.com/vmchale/tokei-vim) by [vmchale](https://github.com/vmchale/)
@@ -424,6 +441,7 @@ Spice
 Sql
 SRecode
 Stratego
+Svelte
 Svg
 Swift
 Swig
@@ -471,6 +489,7 @@ Zsh
 ## Common issues
 
 ### Tokei says I have a lot of D code, but I know there is no D code!
+
 This is likely due to `gcc` generating `.d` files. Until the D people decide on
 a different file extension, you can always exclude `.d` files using the
 `-e --exclude` flag like so
@@ -480,11 +499,13 @@ $ tokei . -e *.d
 ```
 
 ## Canonical Source
+
 The canonical source of this repo is hosted on
 [GitHub](https://github.com/XAMPPRocky/tokei). If you have a GitHub account,
 please make your issues, and pull requests there.
 
 ## Copyright and License
+
 (C) Copyright 2015 by XAMPPRocky and contributors
 
 See [the graph](https://github.com/XAMPPRocky/tokei/graphs/contributors) for a full list of contributors.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Tokei ([時計](https://en.wiktionary.org/wiki/%E6%99%82%E8%A8%88))
-
 [![Mean Bean CI](https://github.com/XAMPPRocky/tokei/workflows/Mean%20Bean%20CI/badge.svg)](https://github.com/XAMPPRocky/tokei/actions?query=workflow%3A%22Mean+Bean+CI%22)
 [![crates.io](https://img.shields.io/crates/d/tokei.svg)](https://crates.io/crates/tokei)
 [![Help Wanted](https://img.shields.io/github/issues/XAMPPRocky/tokei/help%20wanted?color=green)](https://github.com/XAMPPRocky/tokei/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
@@ -9,11 +8,9 @@
 Tokei is a program that displays statistics about your code. Tokei will show the number of files, total lines within those files and code, comments, and blanks grouped by language.
 
 ### Translations
-
 - [中文](https://github.com/chinanf-boy/tokei-zh#支持的语言)
 
 ## Example
-
 ```console
 -------------------------------------------------------------------------------
  Language            Files        Lines         Code     Comments       Blanks
@@ -35,8 +32,8 @@ Tokei is a program that displays statistics about your code. Tokei will show the
 
 - [Features](#features)
 - [Installation](#installation)
-  - [Package Managers](#package-managers)
-  - [Manual](#manual)
+    - [Package Managers](#package-managers)
+    - [Manual](#manual)
 - [How to use Tokei](#how-to-use-tokei)
 - [Options](#options)
 - [Badges](#badges)
@@ -72,7 +69,6 @@ Tokei is a program that displays statistics about your code. Tokei will show the
 ## Installation
 
 ### Package Managers
-
 ```console
 # Arch Linux
 pacman -S tokei
@@ -95,14 +91,11 @@ sudo zypper install tokei
 ### Manual
 
 #### Downloading
-
 You can download prebuilt binaries in the
 [releases section](https://github.com/XAMPPRocky/tokei/releases).
 
 #### Building
-
 You can also build and install from source (requires the latest stable [Rust] compiler.)
-
 ```console
 cargo install --git https://github.com/XAMPPRocky/tokei.git
 ```
@@ -121,20 +114,17 @@ $ tokei ./foo
 ```
 
 #### Multiple folders
-
 To have tokei report on multiple folders in the same call simply add a comma,
 or a space followed by another path.
 
 ```shell
 $ tokei ./foo ./bar ./baz
 ```
-
 ```shell
 $ tokei ./foo, ./bar, ./baz
 ```
 
 #### Excluding folders
-
 Tokei will respect all `.gitignore` and `.ignore` files, and you can use
 the `--exclude` option to exclude any additional files. The `--exclude` flag has
 the same semantics as `.gitignore`.
@@ -144,7 +134,6 @@ $ tokei ./foo --exclude *.rs
 ```
 
 #### Sorting output
-
 By default tokei sorts alphabetically by language name, however using `--sort`
 tokei can also sort by any of the columns.
 
@@ -155,7 +144,6 @@ $ tokei ./foo --sort code
 ```
 
 #### Outputting file statistics
-
 By default tokei only outputs the total of the languages, and using `--files`
 flag tokei can also output individual file statistics.
 
@@ -164,7 +152,6 @@ $ tokei ./foo --files
 ```
 
 #### Outputting into different formats
-
 Tokei normally outputs into a nice human readable format designed for terminals.
 There is also using the `--output` option various other formats that are more
 useful for bringing the data into another program.
@@ -190,7 +177,6 @@ tokei with the features flag.
 ```
 
 **Currently supported formats**
-
 - JSON `--output json`
 - YAML `--output yaml`
 - TOML `--output toml`
@@ -201,7 +187,6 @@ $ tokei ./foo --output json
 ```
 
 #### Reading in stored formats
-
 Tokei can also take in the outputted formats added in the previous results to it's
 current run. Tokei can take either a path to a file, the format passed in as a
 value to the option, or from stdin.
@@ -245,7 +230,6 @@ ARGS:
 ```
 
 ## Badges
-
 Tokei has support for badges. For example
 [![](https://tokei.rs/b1/github/XAMPPRocky/tokei)](https://github.com/XAMPPRocky/tokei).
 
@@ -271,7 +255,6 @@ Example show total lines:
 The server code hosted on tokei.rs is in [XAMPPRocky/tokei_rs](https://github.com/XAMPPRocky/tokei_rs)
 
 ## Plugins
-
 Thanks to contributors tokei is now available as a plugin for some text editors.
 
 - [Vim](https://github.com/vmchale/tokei-vim) by [vmchale](https://github.com/vmchale/)
@@ -489,7 +472,6 @@ Zsh
 ## Common issues
 
 ### Tokei says I have a lot of D code, but I know there is no D code!
-
 This is likely due to `gcc` generating `.d` files. Until the D people decide on
 a different file extension, you can always exclude `.d` files using the
 `-e --exclude` flag like so
@@ -499,13 +481,11 @@ $ tokei . -e *.d
 ```
 
 ## Canonical Source
-
 The canonical source of this repo is hosted on
 [GitHub](https://github.com/XAMPPRocky/tokei). If you have a GitHub account,
 please make your issues, and pull requests there.
 
 ## Copyright and License
-
 (C) Copyright 2015 by XAMPPRocky and contributors
 
 See [the graph](https://github.com/XAMPPRocky/tokei/graphs/contributors) for a full list of contributors.

--- a/languages.json
+++ b/languages.json
@@ -34,13 +34,19 @@
     "Asn1": {
       "name": "ASN.1",
       "line_comment": ["--"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "multi_line_comments": [["/*", "*/"]],
       "extensions": ["asn1"]
     },
     "Assembly": {
       "line_comment": [";"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["asm"]
     },
     "AssemblyGAS": {
@@ -57,7 +63,10 @@
     },
     "AspNet": {
       "name": "ASP.NET",
-      "multi_line_comments": [["<!--", "-->"], ["<%--", "-->"]],
+      "multi_line_comments": [
+        ["<!--", "-->"],
+        ["<%--", "-->"]
+      ],
       "extensions": [
         "asax",
         "ascx",
@@ -85,7 +94,10 @@
       "name": "Shell",
       "shebangs": ["#!/bin/sh"],
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "env": ["sh"],
       "extensions": ["sh"]
     },
@@ -93,7 +105,10 @@
       "name": "BASH",
       "shebangs": ["#!/bin/bash"],
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "env": ["bash"],
       "extensions": ["bash"]
     },
@@ -104,14 +119,20 @@
     },
     "Elvish": {
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "env": ["elvish"],
       "extensions": ["elv"]
     },
     "Fish": {
       "shebangs": ["#!/bin/fish"],
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "env": ["fish"],
       "extensions": ["fish"]
     },
@@ -134,13 +155,19 @@
     "Cassius": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["cassius"]
     },
     "Ceylon": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
+      ],
       "extensions": ["ceylon"]
     },
     "CHeader": {
@@ -179,7 +206,10 @@
     "CoffeeScript": {
       "line_comment": ["#"],
       "multi_line_comments": [["###", "###"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["coffee", "cjsx"]
     },
     "Cogent": {
@@ -188,7 +218,10 @@
     },
     "ColdFusion": {
       "multi_line_comments": [["<!---", "--->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["cfm"]
     },
     "ColdFusionScript": {
@@ -219,7 +252,10 @@
     },
     "Crystal": {
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["cr"]
     },
     "CSharp": {
@@ -240,13 +276,19 @@
       "name": "CSS",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["css"]
     },
     "D": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "nested_comments": [["/+", "+/"]],
       "extensions": ["d"]
     },
@@ -275,13 +317,19 @@
       "quotes": [["\\\"", "\\\""]],
       "nested": true,
       "extensions": ["dm", "dme"],
-      "quotes": [["{\\\"", "\\\"}"], ["'", "'"]]
+      "quotes": [
+        ["{\\\"", "\\\"}"],
+        ["'", "'"]
+      ]
     },
     "Dockerfile": {
       "line_comment": ["#"],
       "extensions": ["dockerfile", "dockerignore"],
       "filenames": ["dockerfile"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]]
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ]
     },
     "DotNetResource": {
       "name": ".NET Resource",
@@ -326,7 +374,11 @@
     },
     "Emojicode": {
       "line_comment": ["💭"],
-      "multi_line_comments": [["💭🔜", "🔚💭"], ["📗", "📗"], ["📘", "📘"]],
+      "multi_line_comments": [
+        ["💭🔜", "🔚💭"],
+        ["📗", "📗"],
+        ["📘", "📘"]
+      ],
       "quotes": [["❌🔤", "❌🔤"]],
       "extensions": ["emojic", "🍇"]
     },
@@ -372,7 +424,10 @@
     "FortranLegacy": {
       "name": "FORTRAN Legacy",
       "line_comment": ["c", "C", "!", "*"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["f", "for", "ftn", "f77", "pfo"]
     },
     "FortranModern": {
@@ -431,13 +486,22 @@
     },
     "Gohtml": {
       "name": "Go HTML",
-      "multi_line_comments": [["<!--", "-->"], ["{{/*", "*/}}"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "multi_line_comments": [
+        ["<!--", "-->"],
+        ["{{/*", "*/}}"]
+      ],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["gohtml"]
     },
     "Graphql": {
       "name": "GraphQL",
-      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
+      ],
       "line_comment": ["#"],
       "extensions": ["gql", "graphql"]
     },
@@ -451,8 +515,14 @@
       "extensions": ["y", "ly"]
     },
     "Handlebars": {
-      "multi_line_comments": [["<!--", "-->"], ["{{!", "}}"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "multi_line_comments": [
+        ["<!--", "-->"],
+        ["{{!", "}}"]
+      ],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["hbs", "handlebars"]
     },
     "Haskell": {
@@ -490,18 +560,27 @@
     "Html": {
       "name": "HTML",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["html", "htm"]
     },
     "Hamlet": {
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["hamlet"]
     },
     "Haxe": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["hx"]
     },
     "Hex": {
@@ -513,7 +592,10 @@
       "nested": true,
       "line_comment": ["--"],
       "multi_line_comments": [["{-", "-}"]],
-      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
+      ],
       "extensions": ["idr", "lidr"],
       "nested": true
     },
@@ -556,7 +638,11 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["`", "`"]
+      ],
       "extensions": ["js", "mjs"]
     },
     "Json": {
@@ -568,33 +654,50 @@
       "name": "JSX",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["`", "`"]
+      ],
       "extensions": ["jsx"]
     },
     "Julia": {
       "line_comment": ["#"],
       "multi_line_comments": [["#=", "=#"]],
-      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
+      ],
       "nested": true,
       "extensions": ["jl"]
     },
     "Julius": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["`", "`"]
+      ],
       "extensions": ["julius"]
     },
     "KakouneScript": {
       "name": "Kakoune script",
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["kak"]
     },
     "Kotlin": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "nested": true,
-      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
+      ],
       "extensions": ["kt", "kts"]
     },
     "Lean": {
@@ -608,12 +711,18 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "extensions": ["less"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]]
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ]
     },
     "Liquid": {
       "name": "Liquid",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["liquid"],
       "multi_line_comments": [["{% comment %}", "{% endcomment %}"]]
     },
@@ -632,7 +741,10 @@
     },
     "LLVM": {
       "line_comment": [";"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["ll"]
     },
     "Logtalk": {
@@ -644,13 +756,19 @@
     "Lua": {
       "line_comment": ["--"],
       "multi_line_comments": [["--[[", "]]"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["lua"]
     },
     "Lucius": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["lucius"]
     },
     "Madlang": {
@@ -674,12 +792,18 @@
     },
     "MoonScript": {
       "line_comment": ["--"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["moon"]
     },
     "Meson": {
       "line_comment": ["#"],
-      "quotes": [["'", "'"], ["'''", "'''"]],
+      "quotes": [
+        ["'", "'"],
+        ["'''", "'''"]
+      ],
       "filenames": ["meson.build", "meson_options.txt"]
     },
     "Mint": {
@@ -688,12 +812,18 @@
     },
     "Mustache": {
       "multi_line_comments": [["{{!", "}}"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["mustache"]
     },
     "Nim": {
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
+      ],
       "extensions": ["nim"]
     },
     "Nix": {
@@ -726,7 +856,10 @@
       "extensions": ["odin"],
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]]
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ]
     },
     "OpenType": {
       "name": "OpenType Feature File",
@@ -745,13 +878,19 @@
     },
     "Pan": {
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["pan", "tpl"]
     },
     "Pascal": {
       "nested": true,
       "line_comment": ["//"],
-      "multi_line_comments": [["{", "}"], ["(*", "*)"]],
+      "multi_line_comments": [
+        ["{", "}"],
+        ["(*", "*)"]
+      ],
       "quotes": [["'", "'"]],
       "extensions": ["pas", "pp"]
     },
@@ -759,38 +898,56 @@
       "shebangs": ["#!/usr/bin/perl"],
       "line_comment": ["#"],
       "multi_line_comments": [["=pod", "=cut"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["pl", "pm"]
     },
     "Perl6": {
       "name": "Rakudo",
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["pl6", "pm6"]
     },
     "Pest": {
       "line_comment": ["//"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["pest"]
     },
     "NotQuitePerl": {
       "name": "Not Quite Perl",
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["nqp"]
     },
     "Php": {
       "name": "PHP",
       "line_comment": ["#", "//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["php"]
     },
     "Polly": {
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["polly"]
     },
     "Pony": {
@@ -805,7 +962,10 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["pcss", "sss"]
     },
     "Processing": {
@@ -851,8 +1011,14 @@
     },
     "Python": {
       "line_comment": ["#"],
-      "doc_quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""], ["'''", "'''"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "doc_quotes": [
+        ["\\\"\\\"\\\"", "\\\"\\\"\\\""],
+        ["'''", "'''"]
+      ],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "env": ["python", "python2", "python3"],
       "extensions": ["py", "pyw"]
     },
@@ -867,7 +1033,10 @@
       "name": "QML",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["qml"]
     },
     "R": {
@@ -883,18 +1052,28 @@
     "Rakefile": {
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "filenames": ["rakefile"],
       "extensions": ["rake"]
     },
     "Razor": {
-      "multi_line_comments": [["<!--", "-->"], ["@*", "*@"]],
+      "multi_line_comments": [
+        ["<!--", "-->"],
+        ["@*", "*@"]
+      ],
       "extensions": ["cshtml"]
     },
     "Renpy": {
       "name": "Ren'Py",
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["`", "`"]
+      ],
       "extensions": ["rpy"]
     },
     "RON": {
@@ -913,14 +1092,20 @@
     "Ruby": {
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "env": ["ruby"],
       "extensions": ["rb"]
     },
     "RubyHtml": {
       "name": "Ruby HTML",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["rhtml", "erb"]
     },
     "Rust": {
@@ -928,7 +1113,11 @@
       "multi_line_comments": [["/*", "*/"]],
       "nested": true,
       "extensions": ["rs"],
-      "quotes": [["\\\"", "\\\""], ["r#\\\"", "\\\"#"], ["#\\\"", "\\\"#"]]
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["r#\\\"", "\\\"#"],
+        ["#\\\"", "\\\"#"]
+      ]
     },
     "ReStructuredText": {
       "blank": true,
@@ -937,7 +1126,10 @@
     "Sass": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["sass", "scss"]
     },
     "Scala": {
@@ -1002,13 +1194,35 @@
       "name": "Stratego/XT",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["$[", "]"], ["$<", ">"], ["${", "}"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["$[", "]"],
+        ["$<", ">"],
+        ["${", "}"]
+      ],
       "extensions": ["str"]
+    },
+    "Svelte": {
+      "name": "Svelete",
+      "line_comment": ["//"],
+      "multi_line_comments": [
+        ["/*", "*/"],
+        ["<!--", "-->"]
+      ],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["`", "`"]
+      ],
+      "extensions": ["svelte"]
     },
     "Svg": {
       "name": "SVG",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["svg"]
     },
     "Swift": {
@@ -1035,7 +1249,10 @@
     "Tcl": {
       "name": "TCL",
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["tcl"]
     },
     "Tex": {
@@ -1051,7 +1268,10 @@
     "Thrift": {
       "line_comment": ["#", "//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["thrift"]
     },
     "Toml": {
@@ -1069,20 +1289,31 @@
       "name": "TSX",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["`", "`"]
+      ],
       "extensions": ["tsx"]
     },
     "Twig": {
       "name": "Twig",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["twig"],
       "multi_line_comments": [["{#", "#}"]]
     },
     "TypeScript": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["`", "`"]
+      ],
       "extensions": ["ts"]
     },
     "UnrealPlugin": {
@@ -1153,7 +1384,10 @@
       "line_comment": ["##"],
       "multi_line_comments": [["#*", "*#"]],
       "extensions": ["vm"],
-      "quotes": [["'", "'"], ["\\\"", "\\\""]]
+      "quotes": [
+        ["'", "'"],
+        ["\\\"", "\\\""]
+      ]
     },
     "Verilog": {
       "line_comment": ["//"],
@@ -1184,25 +1418,41 @@
     "VisualStudioProject": {
       "name": "Visual Studio Project",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["vcproj", "vcxproj"]
     },
     "VimScript": {
       "name": "Vim Script",
       "line_comment": ["\\\""],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["vim"]
     },
     "Vue": {
       "name": "Vue",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["`", "`"]
+      ],
       "extensions": ["vue"]
     },
     "WebAssembly": {
       "line_comment": [";;"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["wat", "wast"]
     },
     "Wolfram": {
@@ -1213,54 +1463,82 @@
     "Xaml": {
       "name": "XAML",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["xaml"]
     },
     "XcodeConfig": {
       "name": "Xcode Config",
       "line_comment": ["//"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["xcconfig"]
     },
     "Xml": {
       "name": "XML",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["xml"]
     },
     "XSL": {
       "name": "XSL",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["xsl", "xslt"]
     },
     "MsBuild": {
       "name": "MSBuild",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["csproj", "vbproj", "fsproj", "props", "targets"]
     },
     "Xtend": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"], ["'''", "'''"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"],
+        ["'''", "'''"]
+      ],
       "extensions": ["xtend"]
     },
     "Yaml": {
       "name": "YAML",
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["yaml", "yml"]
     },
     "Zig": {
       "line_comment": ["//"],
-      "quotes": [["\\\"", "\\\""], ["\\\\", "\n"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["\\\\", "\n"]
+      ],
       "extensions": ["zig"]
     },
     "Zsh": {
       "shebangs": ["#!/bin/zsh"],
       "line_comment": ["#"],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [
+        ["\\\"", "\\\""],
+        ["'", "'"]
+      ],
       "extensions": ["zsh"]
     }
   }

--- a/languages.json
+++ b/languages.json
@@ -34,19 +34,13 @@
     "Asn1": {
       "name": "ASN.1",
       "line_comment": ["--"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "multi_line_comments": [["/*", "*/"]],
       "extensions": ["asn1"]
     },
     "Assembly": {
       "line_comment": [";"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["asm"]
     },
     "AssemblyGAS": {
@@ -63,10 +57,7 @@
     },
     "AspNet": {
       "name": "ASP.NET",
-      "multi_line_comments": [
-        ["<!--", "-->"],
-        ["<%--", "-->"]
-      ],
+      "multi_line_comments": [["<!--", "-->"], ["<%--", "-->"]],
       "extensions": [
         "asax",
         "ascx",
@@ -94,10 +85,7 @@
       "name": "Shell",
       "shebangs": ["#!/bin/sh"],
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["sh"],
       "extensions": ["sh"]
     },
@@ -105,10 +93,7 @@
       "name": "BASH",
       "shebangs": ["#!/bin/bash"],
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["bash"],
       "extensions": ["bash"]
     },
@@ -119,20 +104,14 @@
     },
     "Elvish": {
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["elvish"],
       "extensions": ["elv"]
     },
     "Fish": {
       "shebangs": ["#!/bin/fish"],
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["fish"],
       "extensions": ["fish"]
     },
@@ -155,19 +134,13 @@
     "Cassius": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["cassius"]
     },
     "Ceylon": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
-      ],
+      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "extensions": ["ceylon"]
     },
     "CHeader": {
@@ -206,10 +179,7 @@
     "CoffeeScript": {
       "line_comment": ["#"],
       "multi_line_comments": [["###", "###"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["coffee", "cjsx"]
     },
     "Cogent": {
@@ -218,10 +188,7 @@
     },
     "ColdFusion": {
       "multi_line_comments": [["<!---", "--->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["cfm"]
     },
     "ColdFusionScript": {
@@ -252,10 +219,7 @@
     },
     "Crystal": {
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["cr"]
     },
     "CSharp": {
@@ -276,19 +240,13 @@
       "name": "CSS",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["css"]
     },
     "D": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "nested_comments": [["/+", "+/"]],
       "extensions": ["d"]
     },
@@ -317,19 +275,13 @@
       "quotes": [["\\\"", "\\\""]],
       "nested": true,
       "extensions": ["dm", "dme"],
-      "quotes": [
-        ["{\\\"", "\\\"}"],
-        ["'", "'"]
-      ]
+      "quotes": [["{\\\"", "\\\"}"], ["'", "'"]]
     },
     "Dockerfile": {
       "line_comment": ["#"],
       "extensions": ["dockerfile", "dockerignore"],
       "filenames": ["dockerfile"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ]
+      "quotes": [["\\\"", "\\\""], ["'", "'"]]
     },
     "DotNetResource": {
       "name": ".NET Resource",
@@ -374,11 +326,7 @@
     },
     "Emojicode": {
       "line_comment": ["💭"],
-      "multi_line_comments": [
-        ["💭🔜", "🔚💭"],
-        ["📗", "📗"],
-        ["📘", "📘"]
-      ],
+      "multi_line_comments": [["💭🔜", "🔚💭"], ["📗", "📗"], ["📘", "📘"]],
       "quotes": [["❌🔤", "❌🔤"]],
       "extensions": ["emojic", "🍇"]
     },
@@ -424,10 +372,7 @@
     "FortranLegacy": {
       "name": "FORTRAN Legacy",
       "line_comment": ["c", "C", "!", "*"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["f", "for", "ftn", "f77", "pfo"]
     },
     "FortranModern": {
@@ -486,22 +431,13 @@
     },
     "Gohtml": {
       "name": "Go HTML",
-      "multi_line_comments": [
-        ["<!--", "-->"],
-        ["{{/*", "*/}}"]
-      ],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "multi_line_comments": [["<!--", "-->"], ["{{/*", "*/}}"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["gohtml"]
     },
     "Graphql": {
       "name": "GraphQL",
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
-      ],
+      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "line_comment": ["#"],
       "extensions": ["gql", "graphql"]
     },
@@ -515,14 +451,8 @@
       "extensions": ["y", "ly"]
     },
     "Handlebars": {
-      "multi_line_comments": [
-        ["<!--", "-->"],
-        ["{{!", "}}"]
-      ],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "multi_line_comments": [["<!--", "-->"], ["{{!", "}}"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["hbs", "handlebars"]
     },
     "Haskell": {
@@ -560,27 +490,18 @@
     "Html": {
       "name": "HTML",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["html", "htm"]
     },
     "Hamlet": {
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["hamlet"]
     },
     "Haxe": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["hx"]
     },
     "Hex": {
@@ -592,10 +513,7 @@
       "nested": true,
       "line_comment": ["--"],
       "multi_line_comments": [["{-", "-}"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
-      ],
+      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "extensions": ["idr", "lidr"],
       "nested": true
     },
@@ -638,11 +556,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["`", "`"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["js", "mjs"]
     },
     "Json": {
@@ -654,50 +568,33 @@
       "name": "JSX",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["`", "`"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["jsx"]
     },
     "Julia": {
       "line_comment": ["#"],
       "multi_line_comments": [["#=", "=#"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
-      ],
+      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "nested": true,
       "extensions": ["jl"]
     },
     "Julius": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["`", "`"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["julius"]
     },
     "KakouneScript": {
       "name": "Kakoune script",
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["kak"]
     },
     "Kotlin": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "nested": true,
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
-      ],
+      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "extensions": ["kt", "kts"]
     },
     "Lean": {
@@ -711,18 +608,12 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "extensions": ["less"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ]
+      "quotes": [["\\\"", "\\\""], ["'", "'"]]
     },
     "Liquid": {
       "name": "Liquid",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["liquid"],
       "multi_line_comments": [["{% comment %}", "{% endcomment %}"]]
     },
@@ -741,10 +632,7 @@
     },
     "LLVM": {
       "line_comment": [";"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["ll"]
     },
     "Logtalk": {
@@ -756,19 +644,13 @@
     "Lua": {
       "line_comment": ["--"],
       "multi_line_comments": [["--[[", "]]"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["lua"]
     },
     "Lucius": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["lucius"]
     },
     "Madlang": {
@@ -792,18 +674,12 @@
     },
     "MoonScript": {
       "line_comment": ["--"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["moon"]
     },
     "Meson": {
       "line_comment": ["#"],
-      "quotes": [
-        ["'", "'"],
-        ["'''", "'''"]
-      ],
+      "quotes": [["'", "'"], ["'''", "'''"]],
       "filenames": ["meson.build", "meson_options.txt"]
     },
     "Mint": {
@@ -812,18 +688,12 @@
     },
     "Mustache": {
       "multi_line_comments": [["{{!", "}}"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["mustache"]
     },
     "Nim": {
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["\\\"\\\"\\\"", "\\\"\\\"\\\""]
-      ],
+      "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "extensions": ["nim"]
     },
     "Nix": {
@@ -856,10 +726,7 @@
       "extensions": ["odin"],
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ]
+      "quotes": [["\\\"", "\\\""], ["'", "'"]]
     },
     "OpenType": {
       "name": "OpenType Feature File",
@@ -878,19 +745,13 @@
     },
     "Pan": {
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["pan", "tpl"]
     },
     "Pascal": {
       "nested": true,
       "line_comment": ["//"],
-      "multi_line_comments": [
-        ["{", "}"],
-        ["(*", "*)"]
-      ],
+      "multi_line_comments": [["{", "}"], ["(*", "*)"]],
       "quotes": [["'", "'"]],
       "extensions": ["pas", "pp"]
     },
@@ -898,56 +759,38 @@
       "shebangs": ["#!/usr/bin/perl"],
       "line_comment": ["#"],
       "multi_line_comments": [["=pod", "=cut"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["pl", "pm"]
     },
     "Perl6": {
       "name": "Rakudo",
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["pl6", "pm6"]
     },
     "Pest": {
       "line_comment": ["//"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["pest"]
     },
     "NotQuitePerl": {
       "name": "Not Quite Perl",
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["nqp"]
     },
     "Php": {
       "name": "PHP",
       "line_comment": ["#", "//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["php"]
     },
     "Polly": {
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["polly"]
     },
     "Pony": {
@@ -962,10 +805,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["pcss", "sss"]
     },
     "Processing": {
@@ -1011,14 +851,8 @@
     },
     "Python": {
       "line_comment": ["#"],
-      "doc_quotes": [
-        ["\\\"\\\"\\\"", "\\\"\\\"\\\""],
-        ["'''", "'''"]
-      ],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "doc_quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""], ["'''", "'''"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["python", "python2", "python3"],
       "extensions": ["py", "pyw"]
     },
@@ -1033,10 +867,7 @@
       "name": "QML",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["qml"]
     },
     "R": {
@@ -1052,28 +883,18 @@
     "Rakefile": {
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "filenames": ["rakefile"],
       "extensions": ["rake"]
     },
     "Razor": {
-      "multi_line_comments": [
-        ["<!--", "-->"],
-        ["@*", "*@"]
-      ],
+      "multi_line_comments": [["<!--", "-->"], ["@*", "*@"]],
       "extensions": ["cshtml"]
     },
     "Renpy": {
       "name": "Ren'Py",
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["`", "`"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["rpy"]
     },
     "RON": {
@@ -1092,20 +913,14 @@
     "Ruby": {
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "env": ["ruby"],
       "extensions": ["rb"]
     },
     "RubyHtml": {
       "name": "Ruby HTML",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["rhtml", "erb"]
     },
     "Rust": {
@@ -1113,11 +928,7 @@
       "multi_line_comments": [["/*", "*/"]],
       "nested": true,
       "extensions": ["rs"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["r#\\\"", "\\\"#"],
-        ["#\\\"", "\\\"#"]
-      ]
+      "quotes": [["\\\"", "\\\""], ["r#\\\"", "\\\"#"], ["#\\\"", "\\\"#"]]
     },
     "ReStructuredText": {
       "blank": true,
@@ -1126,10 +937,7 @@
     "Sass": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["sass", "scss"]
     },
     "Scala": {
@@ -1194,35 +1002,20 @@
       "name": "Stratego/XT",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["$[", "]"],
-        ["$<", ">"],
-        ["${", "}"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["$[", "]"], ["$<", ">"], ["${", "}"]],
       "extensions": ["str"]
     },
     "Svelte": {
-      "name": "Svelete",
+      "name": "Svelte",
       "line_comment": ["//"],
-      "multi_line_comments": [
-        ["/*", "*/"],
-        ["<!--", "-->"]
-      ],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["`", "`"]
-      ],
+      "multi_line_comments": [["/*", "*/"], ["<!--", "-->"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["svelte"]
     },
     "Svg": {
       "name": "SVG",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["svg"]
     },
     "Swift": {
@@ -1249,10 +1042,7 @@
     "Tcl": {
       "name": "TCL",
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["tcl"]
     },
     "Tex": {
@@ -1268,10 +1058,7 @@
     "Thrift": {
       "line_comment": ["#", "//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["thrift"]
     },
     "Toml": {
@@ -1289,31 +1076,20 @@
       "name": "TSX",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["`", "`"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["tsx"]
     },
     "Twig": {
       "name": "Twig",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["twig"],
       "multi_line_comments": [["{#", "#}"]]
     },
     "TypeScript": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["`", "`"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["ts"]
     },
     "UnrealPlugin": {
@@ -1384,10 +1160,7 @@
       "line_comment": ["##"],
       "multi_line_comments": [["#*", "*#"]],
       "extensions": ["vm"],
-      "quotes": [
-        ["'", "'"],
-        ["\\\"", "\\\""]
-      ]
+      "quotes": [["'", "'"], ["\\\"", "\\\""]]
     },
     "Verilog": {
       "line_comment": ["//"],
@@ -1418,41 +1191,25 @@
     "VisualStudioProject": {
       "name": "Visual Studio Project",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["vcproj", "vcxproj"]
     },
     "VimScript": {
       "name": "Vim Script",
       "line_comment": ["\\\""],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["vim"]
     },
     "Vue": {
       "name": "Vue",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["`", "`"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["vue"]
     },
     "WebAssembly": {
       "line_comment": [";;"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["wat", "wast"]
     },
     "Wolfram": {
@@ -1463,82 +1220,54 @@
     "Xaml": {
       "name": "XAML",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["xaml"]
     },
     "XcodeConfig": {
       "name": "Xcode Config",
       "line_comment": ["//"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["xcconfig"]
     },
     "Xml": {
       "name": "XML",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["xml"]
     },
     "XSL": {
       "name": "XSL",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["xsl", "xslt"]
     },
     "MsBuild": {
       "name": "MSBuild",
       "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["csproj", "vbproj", "fsproj", "props", "targets"]
     },
     "Xtend": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"],
-        ["'''", "'''"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["'''", "'''"]],
       "extensions": ["xtend"]
     },
     "Yaml": {
       "name": "YAML",
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["yaml", "yml"]
     },
     "Zig": {
       "line_comment": ["//"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["\\\\", "\n"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["\\\\", "\n"]],
       "extensions": ["zig"]
     },
     "Zsh": {
       "shebangs": ["#!/bin/zsh"],
       "line_comment": ["#"],
-      "quotes": [
-        ["\\\"", "\\\""],
-        ["'", "'"]
-      ],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["zsh"]
     }
   }

--- a/languages.json
+++ b/languages.json
@@ -1006,7 +1006,6 @@
       "extensions": ["str"]
     },
     "Svelte": {
-      "name": "Svelte",
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"], ["<!--", "-->"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],

--- a/tests/data/svelte.svelte
+++ b/tests/data/svelte.svelte
@@ -1,0 +1,41 @@
+<!-- 41 lines 15 code 14 comments 12 blanks -->
+<script>
+/*
+Javascript multi-line
+
+Comment
+*/
+ let count = 0;
+
+ // Single line comment
+ function handleClick() {
+     count += 1;
+ }
+</script>
+
+<!---
+
+multi line comment
+
+--->
+
+<button on:click={handleClick}>
+    Clicked {count} {count === 1 ? 'time' : 'times'}
+</button>
+
+<style>
+/*
+
+   CSS
+
+   multi line
+
+
+   comment
+*/
+ button {
+     border-radius: 50;
+     background-color: darkorange;
+ }
+
+</style>


### PR DESCRIPTION
Added support for a Javascript front end framework called [Svelte](https://svelte.dev/). Sadly, it has very similar format to Vue for files so #488 applies to Svelte as well.

Coincidentally I formatted `languages.json` with [prettier](https://github.com/prettier/prettier)