### PR TITLE
Fixed HTML counting JS and CSS comments

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -491,8 +491,9 @@
     },
     "Html": {
       "name": "HTML",
-      "multi_line_comments": [["<!--", "-->"]],
-      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "line_comment": ["//"],
+      "multi_line_comments": [["<!--", "-->"], ["/*", "*/"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "extensions": ["html", "htm"]
     },
     "Hamlet": {

--- a/tests/data/html.html
+++ b/tests/data/html.html
@@ -1,4 +1,4 @@
-<!-- 27 lines 15 code 8 comments 4 blanks -->
+<!-- 46 lines 23 code 15 comments 8 blanks -->
 <!DOCTYPE html>
 <html>
         <head>
@@ -6,6 +6,16 @@
                 <meta name="viewport" content="width=device-width" />
                 <title></title>
                 link
+                <style>
+                 /*
+
+                 CSS multi-line comment
+
+                 */
+                 body {
+                     background-color: pink;
+                 }
+                </style>
         </head>
         <body>
                 body
@@ -23,5 +33,14 @@
         <!--[if IE 8]>
                 IE Special comment
         <![endif]-->
+        <script>
+         /*
+
+         Javascript multi-line comment
+
+         */
+         let x = 5;
+         // Javascript single line comment
+        </script>
 
 </html>


### PR DESCRIPTION
Previously all lines that were `CSS` or `JavaScript` comments were
counted as code, these are now properly counted as comments.

#488 applies to HTML as well :slightly_frowning_face: 