### PR TITLE
Verbatim strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,11 +123,13 @@ The comment should use the syntax of the language you're testing.
 A good example of a test file is [`tests/data/rust.rs`].
 
 ```rust
-// 39 lines 32 code 2 comments 5 blanks
+// 41 lines 33 code 3 comments 5 blanks
 
 /* /**/ */
 fn main() {
-    let start = "/*";
+    let start = r##"/*\"
+\"##;
+    // comment
     loop {
         if x.len() >= 2 && x[0] == '*' && x[1] == '/' { // found the */
             break;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,24 @@ let x = /* There is a reason
     10;
 ```
 
+The `verbatim_quotes` property expects an array of strings, as some languages
+have multiple syntaxes for defining verbatim strings. A verbatim string
+in the context of Tokei is a string literal that can have unescaped `"`s. For example [`CSharp`](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/strings/#regular-and-verbatim-string-literals)
+
+```json
+"CSharp": {
+  "verbatim_quotes": [
+    [
+      "@\\\"",
+      "\\\""
+    ]
+  ]
+```
+
+```csharp
+const string BasePath = @"C:\";
+```
+
 Some languages have a single, standard filename with no extension
 like `Makefile` or `Dockerfile`. These can be defined with the
 `filenames` property:

--- a/build.rs
+++ b/build.rs
@@ -46,6 +46,7 @@ fn generate_languages(out_dir: &OsStr) -> Result<(), Box<dyn error::Error>> {
         }
 
         sort_prop!("quotes");
+        sort_prop!("verbatim_quotes");
         sort_prop!("multi_line");
     }
 

--- a/languages.json
+++ b/languages.json
@@ -208,6 +208,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
+      "verbatim_quotes": [["R\\\"(", ")\\\""]],
       "extensions": ["cc", "cpp", "cxx", "c++", "pcc", "tpp"]
     },
     "CppHeader": {
@@ -229,6 +230,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
+      "verbatim_quotes": [["@\\\"", "\\\""]],
       "extensions": ["cs"]
     },
     "CShell": {
@@ -392,6 +394,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["(*", "*)"]],
       "quotes": [["\\\"", "\\\""]],
+      "verbatim_quotes": [["@\\\"", "\\\""]],
       "extensions": ["fs", "fsi", "fsx", "fsscript"]
     },
     "Futhark": {
@@ -930,7 +933,8 @@
       "multi_line_comments": [["/*", "*/"]],
       "nested": true,
       "extensions": ["rs"],
-      "quotes": [["\\\"", "\\\""], ["r#\\\"", "\\\"#"], ["#\\\"", "\\\"#"]]
+      "quotes": [["\\\"", "\\\""], ["#\\\"", "\\\"#"]],
+      "verbatim_quotes": [["r##\\\"", "\\\"##"], ["r#\\\"", "\\\"#"]]
     },
     "ReStructuredText": {
       "blank": true,

--- a/src/language/language_type.hbs.rs
+++ b/src/language/language_type.hbs.rs
@@ -169,6 +169,28 @@ impl LanguageType {
         }
     }
 
+    /// Returns the verbatim quotes of a language.
+    /// ```
+    /// use tokei::LanguageType;
+    /// let lang = LanguageType::CSharp;
+    /// assert_eq!(lang.verbatim_quotes(), &[("@\"", "\"")]);
+    /// ```
+    pub fn verbatim_quotes(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            {{#each languages}}
+                {{#if this.verbatim_quotes}}
+                    {{~@key}} =>
+                        &[
+                            {{~#each this.verbatim_quotes}}
+                                ( {{~#each this}}"{{this}}",{{~/each}} ),
+                            {{~/each}}
+                        ],
+                {{~/if}}
+            {{~/each}}
+            _ => &[],
+        }
+    }
+
     /// Returns the doc quotes of a language.
     /// ```
     /// use tokei::LanguageType;

--- a/tests/data/cpp.cpp
+++ b/tests/data/cpp.cpp
@@ -1,45 +1,46 @@
-/* 45 lines 37 code 2 comments 6 blanks */
+/* 46 lines 37 code 3 comments 6 blanks */
 
 #include <stdio.h>
 
 // bubble_sort_function
-void bubble_sort (int a[10], int n) {
-    int t;
-    int j = n;
-    int s = 1;
-    while (s > 0) {
-        s = 0;
-        int i = 1;
-        while (i < j) {
-            if (a[i] < a[i - 1]) {
-                t = a[i];
-                a[i] = a[i - 1];
-                a[i - 1] = t;
-                s = 1;
-            }
-            i++;
-        }
-        j--;
+void bubble_sort(int a[10], int n) {
+  int t;
+  int j = n;
+  int s = 1;
+  while (s > 0) {
+    s = 0;
+    int i = 1;
+    while (i < j) {
+      if (a[i] < a[i - 1]) {
+        t = a[i];
+        a[i] = a[i - 1];
+        a[i - 1] = t;
+        s = 1;
+      }
+      i++;
     }
+    j--;
+  }
 }
 
-void main() {
-    int a[] = {4, 65, 2, -31, 0, 99, 2, 83, 782, 1};
-    int n = 10;
-    int i = 0;
+int main() {
+  int a[] = {4, 65, 2, -31, 0, 99, 2, 83, 782, 1};
+  int n = 10;
+  int i = 0;
 
-    printf("Before sorting:\n\n");
-    while (i < n) {
-        printf("%d ", a[i]);
-        i++;
-    }
+  printf(R"(Before sorting:\n\n" )");
+  // Single line comment
+  while (i < n) {
+    printf("%d ", a[i]);
+    i++;
+  }
 
-    bubble_sort(a, n);
+  bubble_sort(a, n);
 
-    printf("\n\nAfter sorting:\n\n");
-    i = 0;
-    while (i < n) {
-        printf("%d ", a[i]);
-        i++;
-    }
+  printf("\n\nAfter sorting:\n\n");
+  i = 0;
+  while (i < n) {
+    printf("%d ", a[i]);
+    i++;
+  }
 }

--- a/tests/data/csharp.cs
+++ b/tests/data/csharp.cs
@@ -1,0 +1,26 @@
+// 26 lines 14 code 7 comments 5 blanks
+namespace Ns
+{
+    /*
+
+    multi-line comment
+
+    */
+    public class Cls
+    {
+        private const string BasePath = @"a:\";
+
+        [Fact]
+        public void MyTest()
+        {
+            // Arrange.
+            Foo();
+
+            // Act.
+            Bar();
+
+            // Assert.
+            Baz();
+        }
+    }
+}

--- a/tests/data/fsharp.fs
+++ b/tests/data/fsharp.fs
@@ -1,4 +1,4 @@
-(* 13 lines 5 code 4 comments 4 blanks *)
+(* 15 lines 6 code 5 comments 4 blanks *)
 
 // Comment
 
@@ -11,3 +11,5 @@ let bar = "(*
     Code
 *)"
 
+let baz = @"a:\"
+// Comment

--- a/tests/data/rust.rs
+++ b/tests/data/rust.rs
@@ -1,8 +1,10 @@
-// 39 lines 32 code 2 comments 5 blanks
+// 41 lines 33 code 3 comments 5 blanks
 
 /* /**/ */
 fn main() {
-    let start = "/*";
+    let start = r##"/*##\"
+\"##;
+    // comment
     loop {
         if x.len() >= 2 && x[0] == '*' && x[1] == '/' { // found the */
             break;


### PR DESCRIPTION
Closes #330 

Adds support for verbatim strings in `Rust`, `CSharp`, `FSharp`, and `C++`. This should be easy enough to add for any other languages in the future. The only weird case for future contributors, here is that `Python` behaves correctly in the current implementation of Tokei and would behave incorrectly in the case of verbatim strings.

## Issues

### Rust

The Rust implementation is fairly naive, ideally `languages.json` would have a regex `/r(#+)"/`, but the dependency on the `regex` crate would add a good chunk to the compile time and would hurt performance, as mentioned in your comment the most common types are implemented here.

### C++

I should've seen this coming, `C++` is incredibly annoying for verbatim strings, the syntax of [`"PREFIX()PREFIX"`](stroustrup.com/C++11FAQ.html#UD-literals) where `PREFIX` can basically be anything. This would ideally be a regular expression as well. An empty `PREFIX` appears to be the most common situation so that's currently what's implemented. It appears that `scc` doesn't work properly for this either as both bare `()`s and prefixed ones produce incorrect results.

Any advice/feedback is greatly appreciated :smile: