### PR TITLE
Add .csx extension for C#

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -229,7 +229,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "extensions": ["cs"]
+      "extensions": ["cs", "csx"]
     },
     "CShell": {
       "name": "C Shell",


### PR DESCRIPTION
`.csx` is used by [dotnet script](https://github.com/filipw/dotnet-script) for C# scripting.