### PR TITLE
Specify the --sort option in the configuration files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::{env, fs, path::PathBuf};
 
 use crate::language::LanguageType;
+use crate::sort::Sort;
 
 /// A configuration struct for how [`Languages::get_statistics`] searches and
 /// counts languages.
@@ -31,6 +32,8 @@ pub struct Config {
     /// Whether to treat doc strings in languages as comments.  *Default:*
     /// `false`.
     pub treat_doc_strings_as_comments: Option<bool>,
+    /// Sort languages. *Default:* `None`. 
+    pub sort: Option<Sort>,
     /// Filters languages searched to just those provided. E.g. A directory
     /// containing `C`, `Cpp`, and `Rust` with a `Config.types` of `[Cpp, Rust]`
     /// will count only `Cpp` and `Rust`. *Default:* `None`.
@@ -95,6 +98,7 @@ impl Config {
             treat_doc_strings_as_comments: current_dir.treat_doc_strings_as_comments.or(home_dir
                 .treat_doc_strings_as_comments
                 .or(conf_dir.treat_doc_strings_as_comments)),
+            sort: current_dir.sort.or(home_dir.sort.or(conf_dir.sort)),
             types: current_dir.types.or(home_dir.types.or(conf_dir.types)),
             no_ignore: current_dir
                 .no_ignore

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     print_header(&mut stdout, &row, columns)?;
 
-    if let Some(sort_category) = cli.sort {
+    let sort = cli
+        .sort
+        .or(config.sort);
+
+    if let Some(sort_category) = sort {
         for (_, ref mut language) in &mut languages {
             language.sort_by(sort_category)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,11 +72,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     print_header(&mut stdout, &row, columns)?;
 
-    let sort = cli
-        .sort
-        .or(config.sort);
-
-    if let Some(sort_category) = sort {
+    if let Some(sort_category) = cli.sort.or(config.sort) {
         for (_, ref mut language) in &mut languages {
             language.sort_by(sort_category)
         }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,7 +1,9 @@
 use std::{borrow::Cow, str::FromStr};
 
+use serde::de::{self, Deserialize, Deserializer};
+
 /// Used for sorting languages.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Sort {
     /// Sort by number blank lines.
     Blanks,
@@ -27,6 +29,17 @@ impl FromStr for Sort {
             "lines" => Sort::Lines,
             s => return Err(format!("Unsupported sorting option: {}", s)),
         })
+    }
+}
+
+impl<'de> Deserialize<'de> for Sort {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+          .parse()
+          .map_err(de::Error::custom)
     }
 }
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, str::FromStr};
 
 /// Used for sorting languages.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Sort {
     /// Sort by number blank lines.
     Blanks,

--- a/tokei.example.toml
+++ b/tokei.example.toml
@@ -1,5 +1,7 @@
 # The width of the terminal output in columns.
 columns = 80
+# Sort languages based on the specified column.
+sort = "lines"
 # If set, tokei will only show the languages in `types`.
 types = ["Python"]
 # Any doc strings (e.g. `"""hello"""` in python) will be counted as comments.


### PR DESCRIPTION
Closes #548.

Allows to specify the --sort option in a configuration file.

~However as for now the sort option in a configuration file is case sensitive while the cli option is not.~

This is my first PR on this project and I'm a Rust beginner so I would be happy to receive some feedback.