### PR TITLE
Fixed the language name Vim Script to Vim script

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1232,7 +1232,7 @@
       "extensions": ["vcproj", "vcxproj"]
     },
     "VimScript": {
-      "name": "Vim Script",
+      "name": "Vim script",
       "line_comment": ["\\\""],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["vim"]


### PR DESCRIPTION
The correct language name for vim is Vim script, not Vim Script.