### PR TITLE
Add saltstack and jinja support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -595,6 +595,11 @@
       ],
       "extensions": ["js", "mjs"]
     },
+    "Jinja": {
+      "line_comment": ["#"],
+      "multi_line_comments": [["{#", "#}"]],
+      "extensions": ["jinja"]
+    },
     "Json": {
       "name": "JSON",
       "blank": true,
@@ -990,6 +995,11 @@
     "ReStructuredText": {
       "blank": true,
       "extensions": ["rst"]
+    },
+    "SaltStack": {
+      "line_comment": ["#"],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["sls"]
     },
     "Sass": {
       "line_comment": ["//"],


### PR DESCRIPTION
Saltstack is just yaml with a different extention.

Jinja only supports {# #} for comments and they are multiline.

There can be jinja in saltstack files but havent figured out how to add support for that.