### PR TITLE
feat: number formatted printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,15 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -75,7 +84,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.1",
  "constant_time_eq",
 ]
 
@@ -645,6 +654,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "num-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+dependencies = [
+ "arrayvec 0.4.12",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,6 +1181,7 @@ dependencies = [
  "hex",
  "ignore",
  "log",
+ "num-format",
  "once_cell",
  "parking_lot",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ term_size = "0.3.2"
 toml = "0.5.6"
 parking_lot = "0.11.0"
 dashmap = { version = "3.11.7", features = ["serde"] }
+num-format = "0.4.0"
 once_cell = "1.4.0"
 regex = "1.3.9"
 serde_json = "1.0.56"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,8 +80,8 @@ impl<'a> Cli<'a> {
                 possible_values(NumberFormatStyle::all())
                 conflicts_with[output]
                 +takes_value
-                "Format of printed numbers, i.e. plain (1234, default), commas (1,234), or dots \
-                 (1.234). Cannot be used with --output.")
+                "Format of printed numbers, i.e. plain (1234, default), commas (1,234), dots \
+                 (1.234), or underscores (1_234). Cannot be used with --output.")
             (@arg verbose: -v --verbose ...
             "Set log output level:
             1: to show unknown file extensions,
@@ -108,7 +108,7 @@ impl<'a> Cli<'a> {
         let num_format_style: NumberFormatStyle = matches
             .value_of("num_format_style")
             .map(parse_or_exit::<NumberFormatStyle>)
-            .unwrap_or(NumberFormatStyle::Plain);
+            .unwrap_or_default();
 
         let number_format = match num_format_style.get_format() {
             Ok(format) => format,

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -9,7 +9,7 @@ use clap::crate_version;
 use num_format::ToFormattedString;
 
 use crate::input::Format;
-use tokei::{CodeStats, Language, LanguageType, Report};
+use tokei::{find_char_boundary, CodeStats, Language, LanguageType, Report};
 
 pub const FALLBACK_ROW_LEN: usize = 79;
 const NO_LANG_HEADER_ROW_LEN: usize = 67;
@@ -68,6 +68,14 @@ pub enum NumberFormatStyle {
     Commas,
     // 1.234
     Dots,
+    // 1_234
+    Underscores,
+}
+
+impl Default for NumberFormatStyle {
+    fn default() -> Self {
+        Self::Plain
+    }
 }
 
 impl FromStr for NumberFormatStyle {
@@ -78,8 +86,9 @@ impl FromStr for NumberFormatStyle {
             "plain" => Ok(Self::Plain),
             "commas" => Ok(Self::Commas),
             "dots" => Ok(Self::Dots),
+            "underscores" => Ok(Self::Underscores),
             _ => Err(format!(
-                "Expected 'plain', 'commas', or 'dots' for num-format, but got '{}'",
+                "Expected 'plain', 'commas', 'underscores', or 'dots' for num-format, but got '{}'",
                 s,
             )),
         }
@@ -92,11 +101,12 @@ impl NumberFormatStyle {
             Self::Plain => "",
             Self::Commas => ",",
             Self::Dots => ".",
+            Self::Underscores => "_",
         }
     }
 
     pub fn all() -> &'static [&'static str] {
-        &["plain", "commas", "dots"]
+        &["commas", "dots", "plain", "underscores"]
     }
 
     pub fn get_format(self) -> Result<num_format::CustomFormat, num_format::Error> {
@@ -429,13 +439,4 @@ impl<W: Write> Printer<W> {
         self.print_language(&total, "Total")?;
         self.print_row()
     }
-}
-
-fn find_char_boundary(s: &str, index: usize) -> usize {
-    for i in 0..4 {
-        if s.is_char_boundary(index + i) {
-            return index + i;
-        }
-    }
-    unreachable!();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,5 +58,5 @@ pub use self::{
     config::Config,
     language::{Language, LanguageType, Languages},
     sort::Sort,
-    stats::{CodeStats, Report},
+    stats::{find_char_boundary, CodeStats, Report},
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         process::exit(0);
     }
 
-    let mut printer = Printer::new(columns, cli.files, io::BufWriter::new(io::stdout()));
+    let mut printer = Printer::new(
+        columns,
+        cli.files,
+        io::BufWriter::new(io::stdout()),
+        cli.number_format,
+    );
 
     if languages.iter().any(|(_, lang)| lang.inaccurate) {
         printer.print_inaccuracy_warning()?;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -93,7 +93,8 @@ impl ops::AddAssign<CodeStats> for Report {
     }
 }
 
-fn find_char_boundary(s: &str, index: usize) -> usize {
+#[doc(hidden)]
+pub fn find_char_boundary(s: &str, index: usize) -> usize {
     for i in 0..4 {
         if s.is_char_boundary(index + i) {
             return index + i;


### PR DESCRIPTION
Closes #256 and #458 

With the major release migrating #458 completely seemed like more work than starting from scratch as a result of the redesign of the printing system.

Adds command line argument to print numbers with commas, plain, or dots.
For example, dots would result in 1.324.

## Benchmark

```text
Tokei Benchmarking Tool
The use of this tool requires tokei, and hyperfine to be installed and available in your PATH variable.
Please enter the path you would like to benchmark:
hyperfine 1.10.0old tokei: tokei 12.0.4 compiled with serialization support: json
    Finished release [optimized] target(s) in 0.07s
Benchmark #1: target/release/tokei ../rust
  Time (mean ± σ):     115.3 ms ±   2.4 ms    [User: 646.5 ms, System: 192.7 ms]
  Range (min … max):   111.6 ms … 121.1 ms    25 runs
 
Benchmark #2: tokei ../rust
  Time (mean ± σ):     116.3 ms ±   2.8 ms    [User: 657.2 ms, System: 190.3 ms]
  Range (min … max):   112.1 ms … 121.2 ms    25 runs
 
Summary  'target/release/tokei ../rust' ran    1.01 ± 0.03 times faster than 'tokei ../rust'
```