### PR TITLE
Haml example

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -471,6 +471,10 @@
     "Happy": {
       "extensions": ["y", "ly"]
     },
+    "Haml": {
+      "extensions": ["haml"],
+      "multi_line_comments": [["/", ""], ["-#", ""]]
+    },
     "Handlebars": {
       "multi_line_comments": [["<!--", "-->"], ["{{!", "}}"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],

--- a/tests/data/haml.haml
+++ b/tests/data/haml.haml
@@ -1,0 +1,18 @@
+/ 18 lines 6 code 11 comments 1 blank
+%section.container
+  %h1 header
+  %h2 sub header
+
+  .content
+  -# Haml silent comment
+  /
+    multi
+    line
+    comment
+  = 3 + 2
+  / comment requires
+  indentation
+  -# multi
+    line
+    silent
+    comment


### PR DESCRIPTION
closes #587 

@XAMPPRocky Would like your input here, Haml seems to be quite the edge case when it comes to comments. As seen in the example


```haml
/ 18 lines 6 code 11 comments 1 blank
%section.container
  %h1 header
  %h2 sub header

  .content
  -# Haml silent comment
  /
    multi
    line
    comment
  = 3 + 2
  / comment requires
  indentation
  -# multi
    line
    silent
    comment
```

which is translated to

```html
<!-- 18 lines 6 code 11 comments 1 blank -->
<section class='container'>
<h1>header</h1>
<h2>sub header</h2>
<div class='content'></div>
<!--
multi
line
comment
-->
5
<!-- comment requires -->
indentation
</section>
```

Looks like we'd have to add support for an indentation requirement and allow for non-terminating multi-line comment blocks. I'm still interested in implementing this if it's worthwhile. :smile: 

This PR was opened to just show an example, the test case will fail due to aforementioned issues.