### PR TITLE
ShellCheck on Bash scripts

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -22,7 +22,7 @@ echo "The use of this tool requires $REQUIRED to be installed and available in y
 echo 'Please enter the path you would like to benchmark:'
 
 if [ -z ${FILE+x} ]; then
-    read input
+    read -r input
 else
     input=$FILE
 fi

--- a/ci/build.bash
+++ b/ci/build.bash
@@ -11,13 +11,12 @@ TARGET_TRIPLE=$2
 # $3 {boolean} = Whether or not building for release or not.
 RELEASE_BUILD=$3
 
-required_arg $CROSS 'CROSS'
-required_arg $TARGET_TRIPLE '<Target Triple>'
+required_arg "$CROSS" 'CROSS'
+required_arg "$TARGET_TRIPLE" '<Target Triple>'
 
 if [ -z "$RELEASE_BUILD" ]; then
-    $CROSS build --target $TARGET_TRIPLE
-    $CROSS build --target $TARGET_TRIPLE --all-features
+    $CROSS build --target "$TARGET_TRIPLE"
+    $CROSS build --target "$TARGET_TRIPLE" --all-features
 else
-    $CROSS build --target $TARGET_TRIPLE --all-features --release
+    $CROSS build --target "$TARGET_TRIPLE" --all-features --release
 fi
-

--- a/ci/set_rust_version.bash
+++ b/ci/set_rust_version.bash
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-rustup default $1
-rustup target add $2
+rustup default "$1"
+rustup target add "$2"

--- a/ci/test.bash
+++ b/ci/test.bash
@@ -9,8 +9,8 @@ CROSS=$1
 # $1 {string} = <Target Triple>
 TARGET_TRIPLE=$2
 
-required_arg $CROSS 'CROSS'
-required_arg $TARGET_TRIPLE '<Target Triple>'
+required_arg "$CROSS" 'CROSS'
+required_arg "$TARGET_TRIPLE" '<Target Triple>'
 
-$CROSS test --target $TARGET_TRIPLE
-$CROSS build --target $TARGET_TRIPLE --all-features
+$CROSS test --target "$TARGET_TRIPLE"
+$CROSS build --target "$TARGET_TRIPLE" --all-features


### PR DESCRIPTION
Fix following ShellCheck warnings.
[SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086): Double quote to prevent globbing and word splitting.
[SC2162](https://github.com/koalaman/shellcheck/wiki/SC2162): read without -r will mangle backslashes