### PR TITLE
ocamllex and ocamlyacc

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -812,7 +812,7 @@
     "OCaml": {
       "quotes": [["\\\"", "\\\""]],
       "multi_line_comments": [["(*", "*)"]],
-      "extensions": ["ml", "mli", "re", "rei"]
+      "extensions": ["ml", "mli", "mll", "mly", "re", "rei"]
     },
     "Odin": {
       "extensions": ["odin"],


### PR DESCRIPTION
[ocamllex and ocamlyacc](https://caml.inria.fr/pub/docs/manual-ocaml/lexyacc.html) are standard parts of the OCaml language distribution and used in compiler prototyping quite a bit.

This was just a one-line addition to `languages.json`.

I had previously added some test data that I checked using the updated binary, but realized that it broke the automated testing since it violated the one file per language structure of the tests directory.