### PR TITLE
Add Alpine Linux into Package Managers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Tokei is a program that displays statistics about your code. Tokei will show the
 
 #### Linux
 ```console
+# Alpine Linux (since 3.13)
+apk add tokei
 # Arch Linux
 pacman -S tokei
 # Cargo


### PR DESCRIPTION
Note: Alpine 3.13 has not been released yet, it should be till the end of this year.