### PR TITLE
FStar language: add single-line comments

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -387,6 +387,7 @@
     "Fstar": {
       "name": "F*",
       "quotes": [["\\\"", "\\\""]],
+      "line_comment": ["//"],
       "multi_line_comments": [["(*", "*)"]],
       "extensions": ["fst"]
     },

--- a/tests/data/fstar.fst
+++ b/tests/data/fstar.fst
@@ -1,10 +1,11 @@
-(* 10 lines 3 code 4 comments 3 blanks *)
+(* 11 lines 3 code 5 comments 3 blanks *)
 
 module Hello
 
 (* multi
    line
    comment *)
-open FStar.IO
+open FStar.IO // uncounted comment
 
+// single line comment
 let main = print_string "Hello, F*!\n" (* uncounted comment *)


### PR DESCRIPTION
Hi,

FStar allows single-line comments, for now, `tokei` counts only multi-lines one: that PR just fixes that, and adds a single-line comment to the test file.

Thanks :)