### PR TITLE
Fix for #684

### DIFF
--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -106,6 +106,7 @@ impl Languages {
             total.code += language.code;
             total.inaccurate |= language.inaccurate;
             total.children.insert(*ty, language.reports.clone());
+            total.reports.extend(language.summarise().reports);
         }
         total
     }


### PR DESCRIPTION
This is the simplest way to restore the original tokei file counting
functionality, even though it might not be the most efficient thanks
to various clones done within `summarise()`.

I also tried to count `children`, but that doesn't yield the correct result.