### PR TITLE
Implement compact output feature (#605)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,7 @@ pub struct Cli<'a> {
     pub print_languages: bool,
     pub sort: Option<Sort>,
     pub types: Option<Vec<LanguageType>>,
+    pub compact: bool,
     pub number_format: num_format::CustomFormat,
     pub verbose: u64,
 }
@@ -83,6 +84,8 @@ impl<'a> Cli<'a> {
             (@arg types: -t --type
                 +takes_value
                 "Filters output by language type, seperated by a comma. i.e. -t=Rust,Markdown")
+            (@arg compact: -C --compact
+                "Do not print statistics about embedded languages.")
             (@arg num_format_style: -n --("num-format")
                 possible_values(NumberFormatStyle::all())
                 conflicts_with[output]
@@ -106,6 +109,7 @@ impl<'a> Cli<'a> {
         let no_ignore_vcs = matches.is_present("no_ignore_vcs");
         let print_languages = matches.is_present("languages");
         let verbose = matches.occurrences_of("verbose");
+        let compact = matches.is_present("compact");
         let types = matches.value_of("types").map(|e| {
             e.split(',')
                 .map(|t| t.parse::<LanguageType>())
@@ -151,6 +155,7 @@ impl<'a> Cli<'a> {
             types,
             verbose,
             number_format,
+            compact,
         };
 
         debug!("CLI Config: {:#?}", cli);

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -293,18 +293,18 @@ impl<W: Write> Printer<W> {
         Ok(())
     }
 
-    pub fn print_results<'a, I>(&mut self, languages: I) -> io::Result<()>
+    pub fn print_results<'a, I>(&mut self, languages: I, compact: bool) -> io::Result<()>
     where
         I: Iterator<Item = (&'a LanguageType, &'a Language)>,
     {
         let (a, b): (Vec<_>, Vec<_>) = languages
             .filter(|(_, v)| !v.is_empty())
-            .partition(|(_, l)| l.children.is_empty());
+            .partition(|(_, l)| compact || l.children.is_empty());
         let mut first = true;
 
         for languages in &[&a, &b] {
             for &(name, language) in *languages {
-                let has_children = !language.children.is_empty();
+                let has_children = !(compact || language.children.is_empty());
                 if first {
                     first = false;
                 } else if has_children || self.list_files {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,9 +86,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             Sort::Lines => languages.sort_by(|a, b| b.1.lines().cmp(&a.1.lines())),
         }
 
-        printer.print_results(languages.into_iter())?
+        printer.print_results(languages.into_iter(), cli.compact)?
     } else {
-        printer.print_results(languages.iter())?
+        printer.print_results(languages.iter(), cli.compact)?
     }
 
     printer.print_total(languages)?;


### PR DESCRIPTION
Fixes #605 

Help text is a good bikeshed topic.

Although it may make sense to avoid searching for embedded languages entirely to maybe gain some performance when running with `--compact`, I left it as an output flag at first to avoid potential counting differences around edge cases.