### PR TITLE
Change display name of Lisp to Common Lisp

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -731,6 +731,7 @@
       "extensions": ["lds"]
     },
     "Lisp": {
+      "name": "Common Lisp",
       "line_comment": [";"],
       "multi_line_comments": [["#|", "|#"]],
       "nested": true,


### PR DESCRIPTION
The term “Lisp” refers to a family of languages including Common Lisp, Emacs Lisp, Clojure, Arc, LFE and the entire Scheme family. While Common Lisp is an important member, it is neither the first nor the only one. It is incorrect to refer to Common Lisp as just Lisp, especially as `tokei` also supports other Lisp dialects like Scheme and Emacs Lisp.