### PR TITLE
Add .asd file extension for Common Lisp

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -734,7 +734,7 @@
       "line_comment": [";"],
       "multi_line_comments": [["#|", "|#"]],
       "nested": true,
-      "extensions": ["lisp", "lsp"]
+      "extensions": ["lisp", "lsp", "asd"]
     },
     "LiveScript": {
       "line_comment": ["#"],


### PR DESCRIPTION
The de-facto standard build facility for Common Lisp, [ASDF](https://common-lisp.net/project/asdf/), uses files with the extension `.asd`. These files are the equivalent of a `Cargo.toml`, but are written in Common Lisp. See [the ASDF manual](https://common-lisp.net/project/asdf/asdf.html#Defining-systems-with-defsystem) for more information.