### PR TITLE
Add extensions output for --languages options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -183,8 +183,8 @@ impl<'a> Cli<'a> {
     }
 
     pub fn print_supported_languages() {
-        for key in LanguageType::list() {
-            println!("{:<25}", key);
+        for (key, extensions) in LanguageType::list() {
+            println!("{} ({})", format!("{}", key), extensions.join(", "));
         }
     }
 

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -54,8 +54,13 @@ impl LanguageType {
     }
 
     /// Provides every variant in a Vec
-    pub fn list() -> &'static [Self] {
-        &[{% for key, _ in languages %}{{key}}, {%- endfor %}]
+    pub fn list() -> &'static [(Self, &'static [&'static str])] {
+        &[{% for key, val in languages -%}
+            ({{key}}, 
+            {% if val.extensions %} &[{% for extension in val.extensions %}"{{extension}}", {% endfor %}],
+            {% else %} &[],
+            {% endif %}),
+        {% endfor %}]
     }
 
     /// Returns the single line comments of a language.


### PR DESCRIPTION
Hi,

As written in issue #660, there is an inconsistency between the help message about `--languages` and actual output.
So I tried to fix them by adding language extensions to the output (because it seems more useful for me).

But I wonder how the output should be arranged. Currently I'm using whitespace as a separator, but is it preferred to be printed in other styles like comma-separated?