### PR TITLE
Cargo install throwing issue during installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can download prebuilt binaries in the
 #### Building
 You can also build and install from source (requires the latest stable [Rust] compiler.)
 ```console
-cargo install --git https://github.com/XAMPPRocky/tokei.git
+cargo install --git https://github.com/XAMPPRocky/tokei.git tokei
 ```
 
 [rust]: https://www.rust-lang.org


### PR DESCRIPTION
The cargo command when run with cargo install --git https://github.com/XAMPPRocky/tokei.git
fails as there are multiple packages with binaries inside the project. For a particular package,
we'd have to add the name of the package, hence adding tokei

Fixes: #769 