### PR TITLE
Support terragrunt hcl extension for HCL language

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -534,7 +534,7 @@
       "line_comment": ["#", "//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "extensions": ["tf", "tfvars"]
+      "extensions": ["hcl", "tf", "tfvars"]
     },
     "Headache": {
       "line_comment": ["//"],


### PR DESCRIPTION
Add support for `.hcl` extension used by terragrunt

https://terragrunt.gruntwork.io/
https://github.com/gruntwork-io/terragrunt
https://terragrunt.gruntwork.io/docs/getting-started/configuration/#formatting-terragrunthcl