### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -336,8 +336,9 @@ impl<W: Write> Printer<W> {
                 }
 
                 if self.list_files {
+                    self.print_subrow()?;
+
                     if !compact {
-                        self.print_subrow()?;
                         let (a, b): (Vec<_>, Vec<_>) = language
                             .reports
                             .iter()
@@ -377,7 +378,6 @@ impl<W: Write> Printer<W> {
                         }
                     } else {
                         // compact format
-                        self.print_subrow()?;
                         for report in &language.reports {
                             writeln!(self.writer, "{:1$}", report, self.path_length)?;
                         }
@@ -440,15 +440,13 @@ impl<W: Write> Printer<W> {
         let name = report.name.to_string_lossy();
         let name_length = name.len();
 
-        if name_length <= self.path_length {
-            self.print_report_total_formatted(name, self.path_length, report)?;
-        } else {
+        if name_length > self.path_length {
             let mut formatted = String::from("|");
             // Add 1 to the index to account for the '|' we add to the output string
             let from = find_char_boundary(&name, name_length + 1 - self.path_length);
             formatted.push_str(&name[from..]);
-            self.print_report_total_formatted(name, self.path_length, report)?;
         }
+        self.print_report_total_formatted(name, self.path_length, report)?;
 
         Ok(())
     }

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -169,9 +169,9 @@ impl AddAssign for Language {
         self.blanks += rhs.blanks;
         self.code += rhs.code;
         self.reports
-            .extend(mem::replace(&mut rhs.reports, Vec::new()));
+            .extend(mem::take(&mut rhs.reports));
         self.children
-            .extend(mem::replace(&mut rhs.children, BTreeMap::new()));
+            .extend(mem::take(&mut rhs.children));
         self.inaccurate |= rhs.inaccurate
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -32,7 +32,7 @@ impl CodeStats {
     pub fn summarise(&self) -> Self {
         let mut summary = self.clone();
 
-        for (_, stats) in std::mem::replace(&mut summary.blobs, BTreeMap::new()) {
+        for (_, stats) in std::mem::take(&mut summary.blobs) {
             let child_summary = stats.summarise();
 
             summary.blanks += child_summary.blanks;

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -97,9 +97,8 @@ pub fn get_all_files<A: AsRef<Path>>(
         match result {
             Ok(stats) => {
                 let func = config.for_each_fn;
-                match func {
-                    Some(f) => f(language, stats.clone()),
-                    None => (),
+                if let Some(f) = func {
+                     f(language, stats.clone())
                 };
                 entry.add_report(stats)
             }


### PR DESCRIPTION
There's also a deprecated function that I didn't want to just change but I'll point it out... in `language/synatx` line 94 you use the `byte_classes` method on the `AhoCorasickBuilder` but apparently [that either doesn't do anything anymore or won't shortly](https://github.com/BurntSushi/aho-corasick/issues/57).