### PR TITLE
add Korn shell to supported languages

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -702,6 +702,14 @@
       "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "extensions": ["kt", "kts"]
     },
+    "Ksh": {
+      "name": "Korn shell",
+      "shebangs": ["#!/bin/ksh"],
+      "line_comment": ["#"],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "env": ["ksh"],
+      "extensions": ["ksh"]
+    },
     "KvLanguage": {
       "name":"KV Language",
       "line_comment": ["# "],

--- a/tests/data/ksh.ksh
+++ b/tests/data/ksh.ksh
@@ -1,0 +1,17 @@
+#!/bin/ksh
+# 17 lines, 11 code, 4 comments, 2 blanks
+
+# first comment
+files="/etc/passwd /etc/group /etc/hosts"
+for f in $files; do
+    if [ ! -f $f ]
+    then
+        echo "$f file missing!"
+    fi
+done
+
+# second comment
+for f in $(ls /tmp/*)
+do
+    print "Full file path in /tmp dir : $f"
+done


### PR DESCRIPTION
Hello,

this commit adds Korn shell to the list of supported languages.
It's default shell in OpenBSD now  https://man.openbsd.org/ksh

thanks.
