### PR TITLE
README: FreeBSD and NetBSD are not Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,20 @@ cargo install tokei
 conda install -c conda-forge tokei
 # Fedora
 sudo dnf install tokei
-# FreeBSD
-pkg install tokei
-# NetBSD
-pkgin install tokei
 # Nix/NixOS
 nix-env -i tokei
 # OpenSUSE
 sudo zypper install tokei
+```
+
+#### FreeBSD
+```console
+pkg install tokei
+```
+
+#### NetBSD
+```console
+pkgin install tokei
 ```
 
 #### macOS


### PR DESCRIPTION
FreeBSD and NetBSD are both independent operating systems, with their own kernels, libcs, rust triples, etc.  They are not Linux distributions.  So move them out of the Linux section into their own sections.
