### PR TITLE
update readme: add tokei-pie in related tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,11 @@ The canonical source of this repo is hosted on
 [GitHub](https://github.com/XAMPPRocky/tokei). If you have a GitHub account,
 please make your issues, and pull requests there.
 
+## Related Tools
+
+- [tokei-pie](https://github.com/laixintao/tokei-pie): Render tokei's output to
+  interactive sunburst chart.
+
 ## Copyright and License
 (C) Copyright 2015 by XAMPPRocky and contributors
 


### PR DESCRIPTION
Hi, I wrote a small tool that can parse `tokei -o json`, use like this `tokei -o json | tokei-pie` then generate a sunburst chart, displaying it by opening a tab in the browser. It is interactive, you can click around the sectors to see the code lines reactively.

It parses `tokei`'s json output so this feature do not touch tokei's code at all.

I think it is handy working with tokei. So I think it may interest other tokei users, so I open this PR.

I know it may be rude for opening a PR to just promote myself's project like this, I totally understand if you don't want to accept this, you can just close it if so. :D

https://github.com/laixintao/tokei-pie