### PR TITLE
Fix input output mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1006,25 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strum"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+
+[[package]]
+name = "strum_macros"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1129,6 +1163,8 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_yaml",
+ "strum",
+ "strum_macros",
  "tempfile",
  "tera",
  "term_size",
@@ -1223,6 +1259,12 @@ checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ optional = true
 version = "0.8.15"
 
 [dev-dependencies]
+strum = "0.23.0"
+strum_macros = "0.23.0"
 regex = "1.4.6"
 tempfile = "3.0.8"
 git2 = { version="0.13.20", default-features=false, features=[] }

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,7 +7,9 @@ type LanguageMap = BTreeMap<LanguageType, Language>;
 
 #[derive(Deserialize, Serialize, Debug)]
 struct Output {
+    #[serde(flatten)]
     languages: LanguageMap,
+    #[serde(rename = "Total")]
     totals: Language,
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,15 @@
-use serde_json::{json, Map};
+use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, error::Error, str::FromStr};
 
 use tokei::{Language, LanguageType, Languages};
 
 type LanguageMap = BTreeMap<LanguageType, Language>;
+
+#[derive(Deserialize, Serialize, Debug)]
+struct Output {
+    languages: LanguageMap,
+    totals: Language,
+}
 
 macro_rules! supported_formats {
     ($(
@@ -20,6 +26,7 @@ macro_rules! supported_formats {
         /// Supported serialization formats.
         ///
         /// To enable all formats compile with the `all` feature.
+        #[cfg_attr(test, derive(strum_macros::EnumIter))]
         #[derive(Debug)]
         pub enum Format {
             Json,
@@ -63,8 +70,9 @@ macro_rules! supported_formats {
                 if input.is_empty() {
                     return None
                 }
-                if let Ok(result) = serde_json::from_str(input) {
-                    return Some(result)
+
+                if let Ok(Output { languages, .. }) = serde_json::from_str::<Output>(input) {
+                    return Some(languages);
                 }
 
                 $(
@@ -73,8 +81,8 @@ macro_rules! supported_formats {
                     {
                         let parse = &{ $parse_kode };
 
-                        if let Ok(result) = parse(input) {
-                            return Some(result)
+                        if let Ok(Output { languages, .. }) = parse(input) {
+                            return Some(languages)
                         }
                     }
                 )+
@@ -84,20 +92,17 @@ macro_rules! supported_formats {
             }
 
             pub fn print(&self, languages: &Languages) -> Result<String, Box<dyn Error>> {
-                // To serde_json Map and add summary
-                let mut map = Map::new();
-                for (language_type, language) in languages.into_iter() {
-                    map.insert(language_type.to_string(), json!(language));
-                }
-
-                map.insert(String::from("Total"), json!(languages.total()));
+                let output = Output {
+                    languages: (*languages).to_owned(),
+                    totals: languages.total()
+                };
 
                 match *self {
-                    Format::Json => Ok(serde_json::to_string(&map)?),
+                    Format::Json => Ok(serde_json::to_string(&output)?),
                     $(
                         #[cfg(feature = $feature)] Format::$variant => {
                             let print= &{ $print_kode };
-                            Ok(print(&map)?)
+                            Ok(print(&output)?)
                         }
                     ),+
                 }
@@ -195,4 +200,32 @@ pub fn add_input(input: &str, languages: &mut Languages) -> bool {
 
 fn convert_input(contents: &str) -> Option<LanguageMap> {
     self::Format::parse(&contents)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use strum::IntoEnumIterator;
+    use tokei::Config;
+
+    use std::path::Path;
+
+    #[test]
+    fn formatting_print_matches_parse() {
+        // Get language results from sample dir
+        let data_dir = Path::new("tests").join("data");
+        let mut langs = Languages::new();
+        langs.get_statistics(&[data_dir], &[], &Config::default());
+
+        // Check that the value matches after serializing and deserializing
+        for variant in Format::iter() {
+            let serialized = variant
+                .print(&langs)
+                .expect(&format!("Failed serializing variant: {:?}", variant));
+            let deserialized = Format::parse(&serialized)
+                .expect(&format!("Failed deserializing variant: {:?}", variant));
+            assert_eq!(*langs, deserialized);
+        }
+    }
 }

--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -17,7 +17,7 @@ use crate::{
 /// directory.
 /// ([_List of
 /// Languages_](https://github.com/XAMPPRocky/tokei#supported-languages))
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Languages {
     inner: BTreeMap<LanguageType, Language>,
 }


### PR DESCRIPTION
Closes: #771 

This PR attempts to fix a couple of issues with the `--output` `--input` flags. The implementation is a breaking change from the old format as described below.

## First mismatch

Before serializing the output an extra `Total` count was added in while deserializing did not account for this and would try to parse `Total` as a `LanguageType`. This was one cause of the deserialization error

## Second mismatch

Serializing previously converted the top level of `LanguageType`s stored in the map to a `String` using `.to_string` before serializing (I'm assuming to get a `String` so that it could be stored with `"Total"`). This differs from how the `LanguageType` would normally get serialized using the `Debug` implementation causing a mismatch when trying to deserialize. E.g. `LanguageType::Bash` with `.to_string()` would be `BASH` while its debug representation is just `Bash`

## Attempted solution

The simplest solution seemed to be to separate out the totals from the full language listing. This avoids having to special case the extra field while providing a better structure for the outputted format.

A test case was added that ensures the serialized then deserialized listing matches the original one for all available formats.

---

This is my first time contributing to this project so let me know if anything looks off or can be improved :)