### PR TITLE
Remove deprecated aho corasick `.byte_classes(false)` toggle

### DIFF
--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -91,7 +91,6 @@ impl SharedMatchers {
             let mut builder = AhoCorasickBuilder::new();
             builder
                 .anchored(anchored)
-                .byte_classes(false)
                 .dfa(true)
                 .prefilter(true);
             builder.build_with_size(pattern).unwrap()


### PR DESCRIPTION
Fixes #766 

I pulled a basic set of decently large repos to test these changes against since there aren't benchmarks and I didn't want to make this change without knowing it wouldn't regress performance too much. I compiled a binary from `master` named `master` as well as one from this branch named `removed` and ran

```console
$ hyperfine --warmup 5 --style none --export-markdown /dev/stdout --parameter-list repo cpython,linux,node,rust,TypeScript './master {repo}' './removed {repo}'
```

from there I restructured things into the following table (keeping only the mean with std dev)

| Repo | `master` (ms) | `removed` (ms) |
| :--- | ---: | ---: |
| `cpython` | 134.1 ± 3.5 | 133.7 ± 2.3 |
| `linux` | 1448.7 ± 21.4 | 1493.6 ± 6.1 |
| `node` | 897.4 ± 3.7 | 897.8 ± 9.6 |
| `rust` | 156.8 ± 4.1 | 155.4 ± 2.8 |
| `TypeScript` | 1164 ± 0.026 | 1150 ± 0.013 |

It looks like the most notable change was with `linux` which is roughly `+3%`
