### PR TITLE
Add blobs to the totals for jupyter

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -46,12 +46,18 @@ impl CodeStats {
 
 impl ops::AddAssign for CodeStats {
     fn add_assign(&mut self, rhs: Self) {
+        self.add_assign(&rhs);
+    }
+}
+
+impl ops::AddAssign<&'_ CodeStats> for CodeStats {
+    fn add_assign(&mut self, rhs: &'_ CodeStats) {
         self.blanks += rhs.blanks;
         self.code += rhs.code;
         self.comments += rhs.comments;
 
-        for (language, stats) in rhs.blobs {
-            *self.blobs.entry(language).or_default() += stats;
+        for (language, stats) in &rhs.blobs {
+            *self.blobs.entry(*language).or_default() += stats;
         }
     }
 }


### PR DESCRIPTION
Fixes #859 

It looks like the blobs when getting stats for jupyter notebooks were getting added as children, but not being added to the root count, so this change simply adds them to the root count as well