### PR TITLE
Add Haml support with indented comments and embeddings

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -532,6 +532,11 @@
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["gw"]
     },
+    "Haml": {
+      "line_comment": ["-#"],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["haml"]
+    },
     "Happy": {
       "extensions": ["y", "ly"]
     },

--- a/languages.json
+++ b/languages.json
@@ -534,6 +534,8 @@
     },
     "Haml": {
       "line_comment": ["-#"],
+      "indent_based_comments": ["/"],
+      "important_syntax": ["/", ":"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["haml"]
     },

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -149,7 +149,8 @@ impl LanguageType {
             let started_in_comments = !syntax.stack.is_empty()
                 || (config.treat_doc_strings_as_comments == Some(true)
                     && syntax.quote.is_some()
-                    && syntax.quote_is_doc_quote);
+                    && syntax.quote_is_doc_quote)
+                || syntax.comment_indent.is_some();
             let ended_with_comments =
                 match syntax.perform_multi_line_analysis(lines, start, end, config) {
                     crate::language::syntax::AnalysisReport::Normal(end) => end,
@@ -172,6 +173,10 @@ impl LanguageType {
                             LanguageContext::Html { language } => {
                                 stats.code += 1;
                                 // Add all the markdown blobs.
+                                *stats.blobs.entry(language).or_default() += blob;
+                            }
+                            LanguageContext::Haml { language } => {
+                                stats.code += 1;
                                 *stats.blobs.entry(language).or_default() += blob;
                             }
                         }

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -80,6 +80,21 @@ impl LanguageType {
         }
     }
 
+    /// Returns the indent-based comments of a language.
+    /// ```
+    /// use tokei::LanguageType;
+    /// let lang = LanguageType::Haml;
+    /// assert_eq!(lang.indent_based_comments(), &["/"]);
+    /// ```
+    pub fn indent_based_comments(self) -> &'static [&'static str]
+    {
+        match self {
+            {% for key, value in languages -%}
+                {{key}} => &[{% for item in value.indent_based_comments | default(value=[]) %}"{{item}}",{% endfor %}],
+            {% endfor %}
+        }
+    }
+
     /// Returns the single line comments of a language.
     /// ```
     /// use tokei::LanguageType;

--- a/tests/data/haml.haml
+++ b/tests/data/haml.haml
@@ -1,0 +1,18 @@
+-# 18 lines 11 code 2 comments 5 blanks
+
+%section.container
+
+  - @posts.each do |post|
+    -# Ruby comment
+    %h1= post.title
+
+    %h2= post.subtitle
+
+    .content
+      = post.content
+
+    /
+      HTML comment. Not detected as of now.
+      %div
+        %span
+          This is all wrapped in a comment

--- a/tests/data/haml.haml
+++ b/tests/data/haml.haml
@@ -1,4 +1,4 @@
--# 18 lines 11 code 2 comments 5 blanks
+-# 36 lines 12 code 16 comments 8 blanks
 
 %section.container
 
@@ -16,3 +16,21 @@
       %div
         %span
           This is all wrapped in a comment
+
+      Caveats: Trailing empty line is counted as a comment.
+    :javascript
+      // JS comment
+      console.log("Hello!");
+
+      /*
+        This is also a comment
+      */
+      // Caveats: trailing empty line is discarded
+    :coffee
+      # CoffeeScript
+
+      console.log "Hello!"
+    :scss
+      // SCSS
+
+      body {}


### PR DESCRIPTION
This is an alternative proposal to https://github.com/XAMPPRocky/tokei/pull/869.

This PR adds support for Haml with indented comments and embeddings like:

```haml
  -# Embeddings
  :javascript
    // This is JavaScript code:
    console.log("Hello!");

  -# Comments
  /
    %p
      This is emitted in an HTML comment.
```

Compared to https://github.com/XAMPPRocky/tokei/pull/869 this is more feature-complete but it makes the Rust implementation more complex. That is why I filed it as a separate proposal.

Known problems:

- Trailing empty lines in embeddings are entirely dropped from counting.
- Trailing empty lines in indented comments are counted as comments, not blanks.
