### PR TITLE
Clap v3 + clippy fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
 dependencies = [
  "atty",
  "bitflags",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -338,6 +338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -513,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1057,9 +1066,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
@@ -1076,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1087,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1122,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "slug"
@@ -1137,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "strsim"
@@ -1168,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1179,13 +1188,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,19 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arbitrary"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
+checksum = "510c76ecefdceada737ea728f4f9a84bd2e1ef29f1ba555e560940fe279954de"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -72,9 +63,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -99,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
 ]
@@ -126,9 +117,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
 ]
@@ -148,34 +139,46 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
 [[package]]
 name = "chrono-tz"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+checksum = "58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552"
 dependencies = [
  "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+dependencies = [
  "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
- "term_size",
+ "termcolor",
+ "terminal_size",
  "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -201,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -212,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -225,31 +228,31 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if",
  "lazy_static",
 ]
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+checksum = "b799062aaf67eb976af3bdca031ee6f846d2f0a5710ddbb0d2efee33f3cc4760"
 dependencies = [
  "cfg-if",
  "num_cpus",
+ "parking_lot",
  "serde",
 ]
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df89dd0d075dea5cc5fdd6d5df6b8a61172a710b3efac1d6bdb9dd8b78f82c1a"
+checksum = "b24629208e87a2d8b396ff43b15c4afb0a69cea3fbbaa9ed9b92b7c02f0aed73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -272,31 +275,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -306,9 +302,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
 ]
@@ -324,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
@@ -368,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -379,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.20"
+version = "0.13.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
 dependencies = [
  "bitflags",
  "libc",
@@ -440,9 +436,15 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -455,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -470,9 +472,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humansize"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
+checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"
@@ -510,25 +512,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.9"
+name = "indexmap"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
@@ -541,15 +559,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.21+1.1.0"
+version = "0.12.26+1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
 dependencies = [
  "cc",
  "libc",
@@ -577,9 +595,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -601,30 +619,30 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ff203f7bdc401350b1dbaa0355135777d25f41c0bbc601851bbd6cf61e8ff5"
+checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -642,7 +660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 dependencies = [
  "arrayvec",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -666,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -676,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
@@ -687,10 +705,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "parking_lot"
-version = "0.11.1"
+name = "os_str_bytes"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -699,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if",
  "instant",
@@ -770,22 +797,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.19"
+name = "phf"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+ "uncased",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -824,18 +890,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -845,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -855,18 +921,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
@@ -907,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -951,6 +1017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,16 +1035,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
-
-[[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -991,9 +1057,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1056a0db1978e9dbf0f6e4fca677f6f9143dc1c19de346f22cac23e422196834"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
@@ -1010,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,23 +1087,23 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.17"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "dtoa",
- "linked-hash-map",
+ "indexmap",
+ "ryu",
  "serde",
  "yaml-rust",
 ]
@@ -1055,6 +1121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
 name = "slug"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,15 +1137,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -1096,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1121,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.8.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64b021b8d3ab1f59ceae9e6cd1c26c8e7ce0322a9ebfff6c0e22b3b66938935"
+checksum = "d3cac831b615c25bcef632d1cabf864fa05813baad3d526829db18eb70e8b58d"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -1161,13 +1233,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "terminal_size"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
- "term_size",
- "unicode-width",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]
@@ -1180,20 +1261,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1214,7 +1285,7 @@ dependencies = [
  "colored",
  "crossbeam-channel",
  "dashmap",
- "dirs-next",
+ "dirs",
  "encoding_rs_io",
  "env_logger",
  "git2",
@@ -1251,15 +1322,24 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "uncased"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -1313,18 +1393,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -1334,12 +1411,6 @@ name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -1361,15 +1432,15 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,39 +32,39 @@ lto = "thin"
 panic = "abort"
 
 [build-dependencies]
-tera = "1.6.1"
-ignore = "0.4.18"
-serde_json = "1.0.64"
+tera = "1.15"
+ignore = "0.4"
+serde_json = "1"
 
 [dependencies]
-aho-corasick = "0.7.15"
-arbitrary = { version="1.0.1", features=["derive"] }
-clap = { version = "2.33.3", features = ["wrap_help"] }
+aho-corasick = "0.7"
+arbitrary = { version = "1", features = ["derive"] }
+clap = { version = "3", features = ["cargo", "wrap_help"] }
 colored = "2"
-crossbeam-channel = "0.5.0"
-encoding_rs_io = "0.1.7"
-grep-searcher = "0.1.8"
-ignore = "0.4.18"
-log = "0.4.11"
+crossbeam-channel = "0.5"
+encoding_rs_io = "0.1"
+grep-searcher = "0.1"
+ignore = "0.4"
+log = "0.4"
 rayon = "1.5.0"
-serde = { version="1.0.128", features=["derive", "rc"] }
-term_size = "0.3.2"
-toml = "0.5.8"
-parking_lot = "0.11.1"
-dashmap = { version="4.0.2", features=["serde"] }
+serde = { version = "1.0.128", features = ["derive", "rc"] }
+term_size = "0.3"
+toml = "0.5"
+parking_lot = "0.11"
+dashmap = { version = "5.0.0", features = ["serde"] }
 num-format = "0.4.0"
-once_cell = "1.5.2"
-regex = "1.4.6"
-serde_json = "1.0.64"
-dirs-next = "2.0.0"
+once_cell = "1.9"
+regex = "1.5"
+serde_json = "1"
+dirs = "4"
 
 [dependencies.env_logger]
 features = []
-version = "0.8.2"
+version = "0.8"
 
 [dependencies.hex]
 optional = true
-version = "0.4.2"
+version = "0.4"
 
 [dependencies.serde_cbor]
 optional = true
@@ -72,12 +72,11 @@ version = "0.11.2"
 
 [dependencies.serde_yaml]
 optional = true
-version = "0.8.15"
+version = "0.8"
 
 [dev-dependencies]
-proptest = "1.0.0"
-strum = "0.23.0"
-strum_macros = "0.23.0"
-regex = "1.4.6"
-tempfile = "3.0.8"
-git2 = { version="0.13.20", default-features=false, features=[] }
+proptest = "1"
+strum = "0.23"
+strum_macros = "0.23"
+tempfile = "3.2"
+git2 = { version = "0.13", default-features = false, features = [] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,6 +104,7 @@ impl Cli {
             )
             .arg(
                 Arg::new("input")
+                    .min_values(1)
                     .conflicts_with("languages")
                     .help("The path(s) to the file or directory to be counted."),
             )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,10 @@ use clap::Arg;
 use clap::{crate_description, ArgMatches};
 use tokei::{Config, LanguageType, Sort};
 
-use crate::{cli_utils::*, input::Format};
+use crate::{
+    cli_utils::{crate_version, parse_or_exit, NumberFormatStyle},
+    input::Format,
+};
 
 /// Used for sorting languages.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -218,7 +221,7 @@ impl Cli {
         let compact = matches.is_present("compact");
         let types = matches.value_of("types").map(|e| {
             e.split(',')
-                .map(|t| t.parse::<LanguageType>())
+                .map(str::parse::<LanguageType>)
                 .filter_map(Result::ok)
                 .collect()
         });
@@ -347,7 +350,7 @@ impl Cli {
 
         config.for_each_fn = match self.streaming {
             Some(Streaming::Json) => Some(|l: LanguageType, e| {
-                println!("{}", serde_json::json!({"language": l.name(), "stats": e}))
+                println!("{}", serde_json::json!({"language": l.name(), "stats": e}));
             }),
             Some(Streaming::Simple) => Some(|l: LanguageType, e| {
                 println!(
@@ -358,7 +361,7 @@ impl Cli {
                     e.stats.code,
                     e.stats.comments,
                     e.stats.blanks
-                )
+                );
             }),
             _ => None,
         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -202,12 +202,18 @@ impl Cli {
                         used with --output.",
                     ),
             )
-            .arg(Arg::new("verbose").long("verbose").short('v').help(
-                "Set log output level:
-                1: to show unknown file extensions,
-                2: reserved for future debugging,
-                3: enable file level trace. Not recommended on multiple files",
-            ))
+            .arg(
+                Arg::new("verbose")
+                    .long("verbose")
+                    .short('v')
+                    .multiple_occurrences(true)
+                    .help(
+                        "Set log output level:
+                        1: to show unknown file extensions,
+                        2: reserved for future debugging,
+                        3: enable file level trace. Not recommended on multiple files",
+                    ),
+            )
             .get_matches();
 
         let columns = matches.value_of("columns").map(parse_or_exit::<usize>);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,8 @@
 use std::mem;
 use std::process;
 
-use clap::{clap_app, crate_description, AppSettings, ArgMatches};
+use clap::Arg;
+use clap::{crate_description, ArgMatches};
 use tokei::{Config, LanguageType, Sort};
 
 use crate::{cli_utils::*, input::Format};
@@ -28,8 +29,8 @@ impl std::str::FromStr for Streaming {
 }
 
 #[derive(Debug)]
-pub struct Cli<'a> {
-    matches: ArgMatches<'a>,
+pub struct Cli {
+    matches: ArgMatches,
     pub columns: Option<usize>,
     pub files: bool,
     pub hidden: bool,
@@ -48,93 +49,162 @@ pub struct Cli<'a> {
     pub verbose: u64,
 }
 
-impl<'a> Cli<'a> {
+impl Cli {
     pub fn from_args() -> Self {
-        let matches = clap_app!(tokei =>
-            (version: &*crate_version())
-            (author: "Erin P. <xampprocky@gmail.com> + Contributors")
-            (about: concat!(
-                    crate_description!(),
-                    "\n",
-                    "Support this project on GitHub Sponsors: https://github.com/sponsors/XAMPPRocky"
-                )
+        let matches = clap::App::new("tokei")
+            .version(&*crate_version())
+            .author("Erin P. <xampprocky@gmail.com> + Contributors")
+            .about(concat!(
+                crate_description!(),
+                "\n",
+                "Support this project on GitHub Sponsors: https://github.com/sponsors/XAMPPRocky"
+            ))
+            .arg(
+                Arg::new("columns")
+                    .long("columns")
+                    .short('c')
+                    .takes_value(true)
+                    .conflicts_with("output")
+                    .help(
+                        "Sets a strict column width of the output, only available for \
+                        terminal output.",
+                    ),
             )
-            (setting: AppSettings::ColoredHelp)
-            (@arg columns: -c --columns
-                +takes_value
-                conflicts_with[output]
-                "Sets a strict column width of the output, only available for \
-                terminal output.")
-            (@arg exclude: -e --exclude
-                +takes_value
-                +multiple number_of_values(1)
-                "Ignore all files & directories matching the pattern.")
-            (@arg files: -f --files
-                "Will print out statistics on individual files.")
-            (@arg file_input: -i --input
-                +takes_value
-                "Gives statistics from a previous tokei run. Can be given a file path, \
-                or \"stdin\" to read from stdin.")
-            (@arg hidden: --hidden "Count hidden files.")
-            (@arg input:
-                conflicts_with[languages] ...
-                "The path(s) to the file or directory to be counted.")
-            (@arg languages: -l --languages
-                conflicts_with[input]
-                "Prints out supported languages and their extensions.")
-            (@arg no_ignore: --("no-ignore")
+            .arg(
+                Arg::new("exclude")
+                    .long("exclude")
+                    .short('e')
+                    .takes_value(true)
+                    .multiple_values(true)
+                    .help("Ignore all files & directories matching the pattern."),
+            )
+            .arg(
+                Arg::new("files")
+                    .long("files")
+                    .short('f')
+                    .help("Will print out statistics on individual files."),
+            )
+            .arg(
+                Arg::new("file_input")
+                    .long("input")
+                    .short('i')
+                    .takes_value(true)
+                    .help(
+                        "Gives statistics from a previous tokei run. Can be given a file path, \
+                        or \"stdin\" to read from stdin.",
+                    ),
+            )
+            .arg(
+                Arg::new("hidden")
+                    .long("hidden")
+                    .help("Count hidden files."),
+            )
+            .arg(
+                Arg::new("input")
+                    .conflicts_with("languages")
+                    .help("The path(s) to the file or directory to be counted."),
+            )
+            .arg(
+                Arg::new("languages")
+                    .long("languages")
+                    .short('l')
+                    .conflicts_with("input")
+                    .help("Prints out supported languages and their extensions."),
+            )
+            .arg(Arg::new("no_ignore").long("no-ignore").help(
                 "Don't respect ignore files (.gitignore, .ignore, etc.). This implies \
-                --no-ignore-parent, --no-ignore-dot, and --no-ignore-vcs.")
-            (@arg no_ignore_parent: --("no-ignore-parent")
+                --no-ignore-parent, --no-ignore-dot, and --no-ignore-vcs.",
+            ))
+            .arg(Arg::new("no_ignore_parent").long("no-ignore-parent").help(
                 "Don't respect ignore files (.gitignore, .ignore, etc.) in parent \
-                directories.")
-            (@arg no_ignore_dot: --("no-ignore-dot")
-                "Don't respect .ignore and .tokeignore files, including those in \
-                parent directories.")
-            (@arg no_ignore_vcs: --("no-ignore-vcs")
-                "Don't respect VCS ignore files (.gitignore, .hgignore, etc.), including \
-                those in parent directories.")
-            (@arg output: -o --output
-                // `all` is used so to fail later with a better error
-                possible_values(Format::all())
-                +takes_value
-                "Outputs Tokei in a specific format. Compile with additional features for more \
-                format support.")
-            (@arg streaming: --streaming
-                possible_values(&["simple", "json"])
-                case_insensitive(true)
-                +takes_value
-                "prints the (language, path, lines, blanks, code, comments) records as simple lines or as Json for batch processing")
-            (@arg sort: -s --sort
-                possible_values(&["files", "lines", "blanks", "code", "comments"])
-                case_insensitive(true)
-                conflicts_with[rsort]
-                +takes_value
-                "Sort languages based on column")
-            (@arg rsort: -r --rsort
-                possible_values(&["files", "lines", "blanks", "code", "comments"])
-                case_insensitive(true)
-                conflicts_with[sort]
-                +takes_value
-                "Reverse sort languages based on column")
-            (@arg types: -t --type
-                +takes_value
-                "Filters output by language type, separated by a comma. i.e. -t=Rust,Markdown")
-            (@arg compact: -C --compact
-                "Do not print statistics about embedded languages.")
-            (@arg num_format_style: -n --("num-format")
-                possible_values(NumberFormatStyle::all())
-                conflicts_with[output]
-                +takes_value
-                "Format of printed numbers, i.e. plain (1234, default), commas (1,234), dots \
-                 (1.234), or underscores (1_234). Cannot be used with --output.")
-            (@arg verbose: -v --verbose ...
-            "Set log output level:
-            1: to show unknown file extensions,
-            2: reserved for future debugging,
-            3: enable file level trace. Not recommended on multiple files")
-        )
-        .get_matches();
+                directories.",
+            ))
+            .arg(Arg::new("no_ignore_dot").long("no-ignore-dot").help(
+                "Don't respect .ignore and .tokeignore files, including this in \
+                parent directories.",
+            ))
+            .arg(Arg::new("no_ignore_vcs").long("no-ignore-vcs").help(
+                "Don't respect VCS ignore files (.gitignore, .hgignore, etc.) including \
+                those in parent directories.",
+            ))
+            .arg(
+                Arg::new("output")
+                    .long("output")
+                    .short('o')
+                    .takes_value(true)
+                    .possible_values(Format::all())
+                    .help(
+                        "Outputs Tokei in a specific format. Compile with additional features for \
+                        more format support.",
+                    ),
+            )
+            .arg(
+                Arg::new("streaming")
+                    .long("streaming")
+                    .takes_value(true)
+                    .possible_values(&["simple", "json"])
+                    .ignore_case(true)
+                    .help(
+                        "prints the (language, path, lines, blanks, code, comments) records as \
+                        simple lines or as Json for batch processing",
+                    ),
+            )
+            .arg(
+                Arg::new("sort")
+                    .long("sort")
+                    .short('s')
+                    .takes_value(true)
+                    .possible_values(&["files", "lines", "blanks", "code", "comments"])
+                    .ignore_case(true)
+                    .conflicts_with("rsort")
+                    .help("Sort languages based on column"),
+            )
+            .arg(
+                Arg::new("rsort")
+                    .long("rsort")
+                    .short('r')
+                    .takes_value(true)
+                    .possible_values(&["files", "lines", "blanks", "code", "comments"])
+                    .ignore_case(true)
+                    .conflicts_with("sort")
+                    .help("Reverse sort languages based on column"),
+            )
+            .arg(
+                Arg::new("types")
+                    .long("types")
+                    .short('t')
+                    .takes_value(true)
+                    .help(
+                        "Filters output by language type, separated by a comma. i.e. \
+                        -t=Rust,Markdown",
+                    ),
+            )
+            .arg(
+                Arg::new("compact")
+                    .long("compact")
+                    .short('C')
+                    .help("Do not print statistics about embedded languages."),
+            )
+            .arg(
+                Arg::new("num_format_style")
+                    .long("num-format")
+                    .short('n')
+                    .takes_value(true)
+                    .possible_values(NumberFormatStyle::all())
+                    .conflicts_with("output")
+                    .help(
+                        "Format of printed numbers, i.e., plain (1234, default), \
+                        commas (1,234), dots (1.234), or underscores (1_234). Cannot be \
+                        used with --output.",
+                    ),
+            )
+            .arg(Arg::new("verbose").long("verbose").short('v').help(
+                "Set log output level:
+                1: to show unknown file extensions,
+                2: reserved for future debugging,
+                3: enable file level trace. Not recommended on multiple files",
+            ))
+            .get_matches();
 
         let columns = matches.value_of("columns").map(parse_or_exit::<usize>);
         let files = matches.is_present("files");
@@ -168,7 +238,8 @@ impl<'a> Cli<'a> {
 
         // Sorting category should be restricted by clap but parse before we do
         // work just in case.
-        let sort = matches.value_of("sort")
+        let sort = matches
+            .value_of("sort")
             .or_else(|| matches.value_of("rsort"))
             .map(parse_or_exit::<Sort>);
         let sort_reverse = matches.value_of("rsort").is_some();

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fmt,
     io::{self, Write},
     process,
@@ -6,7 +7,7 @@ use std::{
 };
 
 use clap::crate_version;
-use colored::*;
+use colored::Colorize;
 use num_format::ToFormattedString;
 
 use crate::input::Format;
@@ -233,8 +234,7 @@ impl<W: Write> Printer<W> {
         name: &str,
         prefix: Option<&str>,
     ) -> io::Result<()> {
-        let mut lang_section_len =
-            self.columns - NO_LANG_ROW_LEN - prefix.as_deref().map_or(0, str::len);
+        let mut lang_section_len = self.columns - NO_LANG_ROW_LEN - prefix.map_or(0, str::len);
         if inaccurate {
             lang_section_len -= IDENT_INACCURATE.len();
         }
@@ -266,18 +266,20 @@ impl<W: Write> Printer<W> {
         language_type: LanguageType,
         stats: &[CodeStats],
     ) -> io::Result<()> {
-        self.print_language_name(false, &language_type.to_string(), Some(&(" |-")))?;
+        self.print_language_name(false, &language_type.to_string(), Some(" |-"))?;
         let mut code = 0;
         let mut comments = 0;
         let mut blanks = 0;
 
-        for stats in stats.iter().map(|s| s.summarise()) {
+        for stats in stats.iter().map(tokei::CodeStats::summarise) {
             code += stats.code;
             comments += stats.comments;
             blanks += stats.blanks;
         }
 
-        if !stats.is_empty() {
+        if stats.is_empty() {
+            Ok(())
+        } else {
             writeln!(
                 self.writer,
                 " {:>6} {:>12} {:>12} {:>12} {:>12}",
@@ -287,8 +289,6 @@ impl<W: Write> Printer<W> {
                 comments.to_formatted_string(&self.number_format),
                 blanks.to_formatted_string(&self.number_format),
             )
-        } else {
-            Ok(())
         }
     }
 
@@ -338,7 +338,11 @@ impl<W: Write> Printer<W> {
                 if self.list_files {
                     self.print_subrow()?;
 
-                    if !compact {
+                    if compact {
+                        for report in &language.reports {
+                            writeln!(self.writer, "{:1$}", report, self.path_length)?;
+                        }
+                    } else {
                         let (a, b): (Vec<_>, Vec<_>) = language
                             .reports
                             .iter()
@@ -346,7 +350,9 @@ impl<W: Write> Printer<W> {
                         for reports in &[&a, &b] {
                             let mut first = true;
                             for report in reports.iter() {
-                                if !report.stats.blobs.is_empty() {
+                                if report.stats.blobs.is_empty() {
+                                    writeln!(self.writer, "{:1$}", report, self.path_length)?;
+                                } else {
                                     if first && a.is_empty() {
                                         writeln!(self.writer, " {}", report.name.display())?;
                                         first = false;
@@ -370,16 +376,9 @@ impl<W: Write> Printer<W> {
                                         new_report,
                                         self.path_length - 3
                                     )?;
-                                    self.print_report_total(&report, language.inaccurate)?;
-                                } else {
-                                    writeln!(self.writer, "{:1$}", report, self.path_length)?;
+                                    self.print_report_total(report, language.inaccurate)?;
                                 }
                             }
-                        }
-                    } else {
-                        // compact format
-                        for report in &language.reports {
-                            writeln!(self.writer, "{:1$}", report, self.path_length)?;
                         }
                     }
                 }
@@ -431,7 +430,7 @@ impl<W: Write> Printer<W> {
             subtotal.stats += stats.summarise();
         }
 
-        self.print_report_with_name(&report)?;
+        self.print_report_with_name(report)?;
 
         Ok(())
     }
@@ -453,7 +452,7 @@ impl<W: Write> Printer<W> {
 
     fn print_report_total_formatted(
         &mut self,
-        name: std::borrow::Cow<'_, str>,
+        name: Cow<'_, str>,
         max_len: usize,
         report: &Report,
     ) -> io::Result<()> {
@@ -475,7 +474,7 @@ impl<W: Write> Printer<W> {
         )
     }
 
-    pub fn print_total(&mut self, languages: tokei::Languages) -> io::Result<()> {
+    pub fn print_total(&mut self, languages: &tokei::Languages) -> io::Result<()> {
         let total = languages.total();
         self.print_row()?;
         self.print_language_in_print_total(&total)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,11 +90,11 @@ impl Config {
     // /// extensions = ["py3"]
     /// ```
     pub fn from_config_files() -> Self {
-        let conf_dir = dirs_next::config_dir()
+        let conf_dir = dirs::config_dir()
             .and_then(Self::get_config)
             .unwrap_or_else(Self::default);
 
-        let home_dir = dirs_next::home_dir()
+        let home_dir = dirs::home_dir()
             .and_then(Self::get_config)
             .unwrap_or_else(Self::default);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,16 +92,16 @@ impl Config {
     pub fn from_config_files() -> Self {
         let conf_dir = dirs::config_dir()
             .and_then(Self::get_config)
-            .unwrap_or_else(Self::default);
+            .unwrap_or_default();
 
         let home_dir = dirs::home_dir()
             .and_then(Self::get_config)
-            .unwrap_or_else(Self::default);
+            .unwrap_or_default();
 
         let current_dir = env::current_dir()
             .ok()
             .and_then(Self::get_config)
-            .unwrap_or_else(Self::default);
+            .unwrap_or_default();
 
         #[allow(clippy::or_fun_call)]
         Config {

--- a/src/input.rs
+++ b/src/input.rs
@@ -201,7 +201,7 @@ pub fn add_input(input: &str, languages: &mut Languages) -> bool {
 }
 
 fn convert_input(contents: &str) -> Option<LanguageMap> {
-    self::Format::parse(&contents)
+    self::Format::parse(contents)
 }
 
 #[cfg(test)]

--- a/src/language/embedding.rs
+++ b/src/language/embedding.rs
@@ -47,7 +47,7 @@ impl<'a> std::fmt::Debug for Capture<'a> {
         f.debug_struct("Capture")
             .field("start", &self.start)
             .field("end", &self.end())
-            .field("text", &String::from_utf8_lossy(&self.text))
+            .field("text", &String::from_utf8_lossy(self.text))
             .finish()
     }
 }

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -23,8 +23,8 @@ use self::LanguageType::*;
 include!(concat!(env!("OUT_DIR"), "/language_type.rs"));
 
 impl LanguageType {
-    /// Parses a given `Path` using the `LanguageType`. Returning `Report`
-    /// on success and giving back ownership of PathBuf on error.
+    /// Parses a given [`Path`] using the [`LanguageType`]. Returning [`Report`]
+    /// on success and giving back ownership of [`PathBuf`] on error.
     pub fn parse(self, path: PathBuf, config: &Config) -> Result<Report, (io::Error, PathBuf)> {
         let text = {
             let f = match File::open(&path) {
@@ -47,12 +47,12 @@ impl LanguageType {
         Ok(stats)
     }
 
-    /// Parses the text provided as the given `LanguageType`.
+    /// Parses the text provided as the given [`LanguageType`].
     pub fn parse_from_str<A: AsRef<str>>(self, text: A, config: &Config) -> CodeStats {
         self.parse_from_slice(text.as_ref().as_bytes(), config)
     }
 
-    /// Parses the bytes provided as the given `LanguageType`.
+    /// Parses the bytes provided as the given [`LanguageType`].
     pub fn parse_from_slice<A: AsRef<[u8]>>(self, text: A, config: &Config) -> CodeStats {
         let text = text.as_ref();
 

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -59,7 +59,7 @@ impl LanguageType {
     /// Provides every variant in a Vec
     pub fn list() -> &'static [(Self, &'static [&'static str])] {
         &[{% for key, val in languages -%}
-            ({{key}}, 
+            ({{key}},
             {% if val.extensions %} &[{% for extension in val.extensions %}"{{extension}}", {% endfor %}],
             {% else %} &[],
             {% endif %}),
@@ -278,7 +278,7 @@ impl LanguageType {
     {
         let entry = entry.as_ref();
 
-        if let Some(filename) = fsutils::get_filename(&entry) {
+        if let Some(filename) = fsutils::get_filename(entry) {
             match &*filename {
                 {% for key, value in languages -%}
                     {%- if value.filenames -%}
@@ -292,7 +292,7 @@ impl LanguageType {
             }
         }
 
-        match fsutils::get_extension(&entry) {
+        match fsutils::get_extension(entry) {
             Some(extension) => LanguageType::from_file_extension(extension.as_str()),
             None => LanguageType::from_shebang(&entry),
         }
@@ -307,6 +307,7 @@ impl LanguageType {
     ///
     /// assert_eq!(rust, Some(LanguageType::Rust));
     /// ```
+    #[must_use]
     pub fn from_file_extension(extension: &str) -> Option<Self> {
         match extension {
             {% for key, value in languages -%}
@@ -330,6 +331,7 @@ impl LanguageType {
     ///
     /// assert_eq!(lang, Some(LanguageType::JavaScript));
     /// ```
+    #[must_use]
     pub fn from_mime(mime: &str) -> Option<Self> {
         match mime {
             {% for key, value in languages -%}

--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -44,20 +44,20 @@ impl<'de> serde::Deserialize<'de> for Languages {
 
 impl Languages {
     fn from_previous(map: BTreeMap<LanguageType, Language>) -> Self {
-        use std::collections::btree_map::Entry::*;
-        let mut _self = Self::new();
+        use std::collections::btree_map::Entry;
+        let mut me = Self::new();
 
         for (name, input_language) in map {
-            match _self.entry(name) {
-                Occupied(mut entry) => {
+            match me.entry(name) {
+                Entry::Occupied(mut entry) => {
                     *entry.get_mut() += input_language;
                 }
-                Vacant(entry) => {
+                Entry::Vacant(entry) => {
                     entry.insert(input_language);
                 }
             }
         }
-        _self
+        me
     }
 
     /// Populates the `Languages` struct with statistics about languages
@@ -93,11 +93,13 @@ impl Languages {
     /// # use tokei::*;
     /// let languages = Languages::new();
     /// ```
+    #[must_use]
     pub fn new() -> Self {
         Languages::default()
     }
 
     /// Summary of the Languages struct.
+    #[must_use]
     pub fn total(self: &Languages) -> Language {
         let mut total = Language::new();
         for (ty, language) in self {

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -7,10 +7,7 @@ use std::{collections::BTreeMap, mem, ops::AddAssign};
 
 pub use self::{language_type::*, languages::Languages};
 
-use crate::{
-    sort::Sort::{self, *},
-    stats::Report,
-};
+use crate::{sort::Sort, stats::Report};
 
 /// A struct representing statistics about a single Language.
 #[derive(Clone, Debug, Deserialize, Default, PartialEq, Serialize)]
@@ -36,12 +33,14 @@ impl Language {
     /// # use tokei::*;
     /// let mut rust = Language::new();
     /// ```
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Returns the total number of lines.
     #[inline]
+    #[must_use]
     pub fn lines(&self) -> usize {
         self.blanks + self.code + self.comments
     }
@@ -69,6 +68,7 @@ impl Language {
     /// of the language that doesn't contain any children. It will count
     /// non-blank lines in child languages as code unless the child language is
     /// considered "literate" then it will be counted as comments.
+    #[must_use]
     pub fn summarise(&self) -> Language {
         let mut summary = self.clone();
 
@@ -125,6 +125,7 @@ impl Language {
     ///
     /// assert!(rust.is_empty());
     /// ```
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.code == 0 && self.comments == 0 && self.blanks == 0 && self.children.is_empty()
     }
@@ -148,15 +149,15 @@ impl Language {
     /// ```
     pub fn sort_by(&mut self, category: Sort) {
         match category {
-            Blanks => self
+            Sort::Blanks => self
                 .reports
                 .sort_by(|a, b| b.stats.blanks.cmp(&a.stats.blanks)),
-            Comments => self
+            Sort::Comments => self
                 .reports
                 .sort_by(|a, b| b.stats.comments.cmp(&a.stats.comments)),
-            Code => self.reports.sort_by(|a, b| b.stats.code.cmp(&a.stats.code)),
-            Files => self.reports.sort_by(|a, b| a.name.cmp(&b.name)),
-            Lines => self
+            Sort::Code => self.reports.sort_by(|a, b| b.stats.code.cmp(&a.stats.code)),
+            Sort::Files => self.reports.sort_by(|a, b| a.name.cmp(&b.name)),
+            Sort::Lines => self
                 .reports
                 .sort_by(|a, b| b.stats.lines().cmp(&a.stats.lines())),
         }
@@ -170,6 +171,6 @@ impl AddAssign for Language {
         self.code += rhs.code;
         self.reports.extend(mem::take(&mut rhs.reports));
         self.children.extend(mem::take(&mut rhs.children));
-        self.inaccurate |= rhs.inaccurate
+        self.inaccurate |= rhs.inaccurate;
     }
 }

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -168,10 +168,8 @@ impl AddAssign for Language {
         self.comments += rhs.comments;
         self.blanks += rhs.blanks;
         self.code += rhs.code;
-        self.reports
-            .extend(mem::take(&mut rhs.reports));
-        self.children
-            .extend(mem::take(&mut rhs.children));
+        self.reports.extend(mem::take(&mut rhs.reports));
+        self.children.extend(mem::take(&mut rhs.children));
         self.inaccurate |= rhs.inaccurate
     }
 }

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -64,6 +64,7 @@ pub(crate) struct SharedMatchers {
     pub allows_nested: bool,
     pub doc_quotes: &'static [(&'static str, &'static str)],
     pub important_syntax: AhoCorasick<u16>,
+    #[allow(dead_code)]
     pub any_comments: &'static [&'static str],
     pub is_fortran: bool,
     pub is_literate: bool,
@@ -89,10 +90,7 @@ impl SharedMatchers {
     pub fn init(language: LanguageType) -> Self {
         fn init_corasick(pattern: &[&'static str], anchored: bool) -> AhoCorasick<u16> {
             let mut builder = AhoCorasickBuilder::new();
-            builder
-                .anchored(anchored)
-                .dfa(true)
-                .prefilter(true);
+            builder.anchored(anchored).dfa(true).prefilter(true);
             builder.build_with_size(pattern).unwrap()
         }
 

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -6,7 +6,9 @@ use grep_searcher::LineStep;
 use log::Level::Trace;
 use once_cell::sync::Lazy;
 
-use super::embedding::*;
+use super::embedding::{
+    RegexCache, RegexFamily, ENDING_MARKDOWN_REGEX, END_SCRIPT, END_STYLE, END_TEMPLATE,
+};
 use crate::{stats::CodeStats, utils::ext::SliceExt, Config, LanguageType};
 
 /// Tracks the syntax of the language as well as the current state in the file.
@@ -176,7 +178,9 @@ impl SyntaxCounter {
             stats.blanks += 1;
             trace!("Blank No.{}", stats.blanks);
             true
-        } else if !self.shared.important_syntax.is_match(line) {
+        } else if self.shared.important_syntax.is_match(line) {
+            false
+        } else {
             trace!("^ Skippable");
 
             if self.shared.is_literate
@@ -194,8 +198,6 @@ impl SyntaxCounter {
             }
 
             true
-        } else {
-            false
         }
     }
 
@@ -366,21 +368,18 @@ impl SyntaxCounter {
                 let start_of_code = opening_fence.end();
                 let closing_fence = ENDING_MARKDOWN_REGEX.find(&lines[start_of_code..]);
                 if let Some(m) = &closing_fence {
-                    trace!("{:?}", String::from_utf8_lossy(m.as_bytes()))
+                    trace!("{:?}", String::from_utf8_lossy(m.as_bytes()));
                 }
                 let end_of_code = closing_fence
-                    .map(|fence| start_of_code + fence.start())
-                    .unwrap_or_else(|| lines.len());
-                let end_of_code_block = closing_fence
-                    .map(|fence| start_of_code + fence.end())
-                    .unwrap_or_else(|| lines.len());
+                    .map_or_else(|| lines.len(), |fence| start_of_code + fence.start());
+                let end_of_code_block =
+                    closing_fence.map_or_else(|| lines.len(), |fence| start_of_code + fence.end());
                 let balanced = closing_fence.is_some();
                 let identifier = &opening_fence.as_bytes().trim()[3..];
 
                 let language = identifier
                     .split(|&b| b == b',')
-                    .filter_map(|s| LanguageType::from_str(&String::from_utf8_lossy(s)).ok())
-                    .next()?;
+                    .find_map(|s| LanguageType::from_str(&String::from_utf8_lossy(s)).ok())?;
                 trace!(
                     "{} BLOCK: {:?}",
                     language,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,11 @@ use std::{error::Error, io, process};
 
 use tokei::{Config, Languages, Sort};
 
-use crate::{cli::Cli, cli_utils::*, input::*};
+use crate::{
+    cli::Cli,
+    cli_utils::{Printer, FALLBACK_ROW_LEN},
+    input::add_input,
+};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut cli = Cli::from_args();
@@ -92,7 +96,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     if let Some(sort_category) = cli.sort.or(config.sort) {
         for (_, ref mut language) in &mut languages {
-            language.sort_by(sort_category)
+            language.sort_by(sort_category);
         }
 
         let mut languages: Vec<_> = languages.iter().collect();
@@ -106,15 +110,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         if cli.sort_reverse {
-            printer.print_results(languages.into_iter().rev(), cli.compact)?
+            printer.print_results(languages.into_iter().rev(), cli.compact)?;
         } else {
-            printer.print_results(languages.into_iter(), cli.compact)?
+            printer.print_results(languages.into_iter(), cli.compact)?;
         }
     } else {
-        printer.print_results(languages.iter(), cli.compact)?
+        printer.print_results(languages.iter(), cli.compact)?;
     }
 
-    printer.print_total(languages)?;
+    printer.print_total(&languages)?;
 
     Ok(())
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -18,17 +18,20 @@ pub struct CodeStats {
 
 impl CodeStats {
     /// Creates a new blank `CodeStats`.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Get the total lines in a blob of code.
+    #[must_use]
     pub fn lines(&self) -> usize {
         self.blanks + self.code + self.comments
     }
 
     /// Creates a new `CodeStats` from an existing one with all of the child
     /// blobs merged.
+    #[must_use]
     pub fn summarise(&self) -> Self {
         let mut summary = self.clone();
 
@@ -76,8 +79,9 @@ impl Report {
     /// Create a new `Report` from a [`PathBuf`].
     ///
     /// [`PathBuf`]: //doc.rust-lang.org/std/path/struct.PathBuf.html
+    #[must_use]
     pub fn new(name: PathBuf) -> Self {
-        Report {
+        Self {
             name,
             ..Self::default()
         }
@@ -91,6 +95,7 @@ impl ops::AddAssign<CodeStats> for Report {
 }
 
 #[doc(hidden)]
+#[must_use]
 pub fn find_char_boundary(s: &str, index: usize) -> usize {
     for i in 0..4 {
         if s.is_char_boundary(index + i) {

--- a/src/utils/ext.rs
+++ b/src/utils/ext.rs
@@ -8,7 +8,7 @@ pub(crate) trait AsciiExt {
 
 impl AsciiExt for u8 {
     fn is_whitespace(&self) -> bool {
-        *self == b' ' || (b'\x09'..=b'\x0d').contains(&self)
+        *self == b' ' || (b'\x09'..=b'\x0d').contains(self)
     }
 
     fn is_not_line_ending_whitespace(&self) -> bool {
@@ -60,7 +60,7 @@ impl SliceExt for [u8] {
         let length = self.len();
 
         if length == 0 {
-            return &self;
+            return self;
         }
 
         let start = match self.iter().position(|c| !c.is_whitespace()) {
@@ -75,7 +75,7 @@ impl SliceExt for [u8] {
         let length = self.len();
 
         if length == 0 {
-            return &self;
+            return self;
         }
 
         let start = match self.iter().position(|c| !c.is_whitespace()) {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -88,10 +88,10 @@ pub fn get_all_files<A: AsRef<Path>>(
     let rx_iter = rx
         .into_iter()
         .par_bridge()
-        .filter_map(|e| LanguageType::from_path(e.path(), &config).map(|l| (e, l)));
+        .filter_map(|e| LanguageType::from_path(e.path(), config).map(|l| (e, l)));
 
     let process = |(entry, language): (DirEntry, LanguageType)| {
-        let result = language.parse(entry.into_path(), &config);
+        let result = language.parse(entry.into_path(), config);
         let mut lock = languages.lock();
         let entry = lock.entry(language).or_insert_with(Language::new);
         match result {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -98,7 +98,7 @@ pub fn get_all_files<A: AsRef<Path>>(
             Ok(stats) => {
                 let func = config.for_each_fn;
                 if let Some(f) = func {
-                     f(language, stats.clone())
+                    f(language, stats.clone())
                 };
                 entry.add_report(stats)
             }


### PR DESCRIPTION
Upgrades to clap version 3, this one uses the builder method, although I feel the derive version may be better suited here. Additionally, it fixes several lints reported by clippy.

I ran `cargo test` and it passed successfully, is there anything else that should be done?