### PR TITLE
Add Autoit scripting language

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -98,6 +98,11 @@
       "line_comment": ["#", "dnl"],
       "extensions": ["in"]
     },
+    "Autoit": {
+      "line_comment": [";"],
+      "multi_line_comments": [["#comments-start", "#comments-end"], ["#cs", "#ce"]],
+      "extensions": ["au3"]
+    },
     "AutoHotKey": {
       "line_comment": [";"],
       "multi_line_comments": [["/*", "*/"]],


### PR DESCRIPTION
Add support to Autoit scripting language
something about this language is the multiline comment Keyword can also comment out with ';' but I was not sure how can I add this in language json...
```autoit
#include <MsgBoxConstants.au3>

#comments-start
    MsgBox($MB_SYSTEMMODAL, "", "This won't display ")
    MsgBox($MB_SYSTEMMODAL, "", "nor will this.")
#comments-end

; #cs <- here we commented multiline comment keyword...
MsgBox($MB_SYSTEMMODAL, "", "This will display if '#cs/#ce' are commented out.")
; #ce <- here we commented multiline comment keyword...
```






