### PR TITLE
Add env match for Groovy

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -525,6 +525,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
+      "env": ["groovy"],
       "extensions": ["groovy", "grt", "gtpl", "gvy"]
     },
     "Gwion": {


### PR DESCRIPTION
The standard #!/usr/bin/env is documented for Groovy [1] so add the
match for this.

[1] https://groovy-lang.org/syntax.html#_shebang_line