### PR TITLE
Summarise language before adding to total

### DIFF
--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -102,7 +102,8 @@ impl Languages {
     #[must_use]
     pub fn total(self: &Languages) -> Language {
         let mut total = Language::new();
-        for (ty, language) in self {
+        for (ty, l) in self {
+            let language = l.summarise();
             total.comments += language.comments;
             total.blanks += language.blanks;
             total.code += language.code;


### PR DESCRIPTION
Fixes issue where child languages are not included in the global total.

Before (a6c31a10bc8df7e1a659a7decc4d6d9d43031ddf):

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Language            Files        Lines         Code     Comments       Blanks
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Rust                    4         1490         1066          208          216
 |- Markdown             4          754            0          569          185
 (Total)                           2244         1066          777          401
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Total                   4         1490         1066          208          216
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

After:

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Language            Files        Lines         Code     Comments       Blanks
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Rust                    4         1490         1066          208          216
 |- Markdown             4          754            0          569          185
 (Total)                           2244         1066          777          401
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Total                   4         2244         1066          777          401
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

AFAICT this should provide a partial fix to #713, particularly points 2 & 3 in the initial issue comment:

> 2. The total does not include any comments or blanks.
> 3. The total disagrees with the total for the rust section