### PR TITLE
Perf: prefer non-allocating, case-insensitive string comparisons

### DIFF
--- a/src/sort.rs
+++ b/src/sort.rs
@@ -21,13 +21,18 @@ impl FromStr for Sort {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s.to_lowercase().as_ref() {
-            "blanks" => Sort::Blanks,
-            "comments" => Sort::Comments,
-            "code" => Sort::Code,
-            "files" => Sort::Files,
-            "lines" => Sort::Lines,
-            s => return Err(format!("Unsupported sorting option: {}", s)),
+        Ok(if s.eq_ignore_ascii_case("blanks") {
+            Sort::Blanks
+        } else if s.eq_ignore_ascii_case("comments") {
+            Sort::Comments
+        } else if s.eq_ignore_ascii_case("code") {
+            Sort::Code
+        } else if s.eq_ignore_ascii_case("files") {
+            Sort::Files
+        } else if s.eq_ignore_ascii_case("lines") {
+            Sort::Lines
+        } else {
+            return Err(format!("Unsupported sorting option: {}", s));
         })
     }
 }


### PR DESCRIPTION
# Overview
Hello there! This PR removes the usage of the `to_lowercase` method in the `sort` module. I noticed that its goal was to perform case-insensitive pattern-matching, but it unfortunately requires an allocation (due to the `String` return type). The same goal may be achieved through the `eq_ignore_ascii_case` method, albeit with chained `if` conditions rather than a single `match` expression. The upside is that we no longer require the short-lived allocation.

# Some Minor Changes in Behavior
I must note that `--sort code` and `--sort CoDe` (for example) will both still work. However, behavior will change if we give an invalid item such as `--sort hello`. Observe that the `else` block will consume all other cases. Hence, the printed error will exactly copy the incorrect input.

```
$ tokei ... --sort hello
Unsupported sorting option: hello

$ tokei ... --sort HeLlO
Unsupported sorting option: HeLlO
```

Previously, the `to_lowercase` method would have printed `hello` in all cases. I thought that this is just something worth noting during the review.

Anyway, that is all. Thanks! 🎉