### PR TITLE
add Puppet to tokei; steal .pp from Pascal

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -932,7 +932,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["{", "}"], ["(*", "*)"]],
       "quotes": [["'", "'"]],
-      "extensions": ["pas", "pp"]
+      "extensions": ["pas"]
     },
     "Perl": {
       "shebangs": ["#!/usr/bin/perl"],
@@ -1029,6 +1029,11 @@
         ["#{`", "`}"]
       ],
       "extensions": ["pug"]
+    },
+    "Puppet": {
+      "line_comment": ["#"],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["pp"]
     },
     "PureScript": {
       "nested": true,

--- a/tests/data/puppet.pp
+++ b/tests/data/puppet.pp
@@ -1,0 +1,18 @@
+# 18 lines 14 code 3 comments 1 blanks
+class example::class(
+  $param1,
+  $param2=2,
+  $param3=undef,  # pass this one
+) {
+  # comments are really simple
+  some::resource {
+    'bar':
+      param1 => param2,
+      # comments here too
+      param3 => param4;
+  }
+
+  some::other::resource {
+    'baz':
+  }
+}


### PR DESCRIPTION
Add support for counting lines in [Puppet manifests](https://puppet.com).

Note that some Pascal files do use the `.pp` file extension (although I think `.pas` is more common in the wild); I suspect that Puppet is probably more common than Pascal, so it's probably a fair tradeoff to drop the second-most-common pascal extension.