### PR TITLE
add m4 language definition

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -814,6 +814,11 @@
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["lucius"]
     },
+    "M4": {
+      "extensions": ["m4"],
+      "line_comment": ["#", "dnl"],
+      "quotes": [["`", "'"]]
+    },
     "Madlang": {
       "extensions": ["mad"],
       "line_comment": ["#"],

--- a/tests/data/m4.m4
+++ b/tests/data/m4.m4
@@ -1,0 +1,7 @@
+dnl 7 lines 3 code 1 blanks 3 comments
+The builtin `dnl' stands for “Discard to Next Line”:
+dnl this line is not emitted
+Other text is emitted
+
+You can also make comments with `#' # this is a comment
+# This is a comment, too


### PR DESCRIPTION
This is necessarily kind of fuzzy because m4 supports _changing_ the comment character with the [changecom](https://www.gnu.org/software/m4/manual/html_node/Changecom.html) macro, and `dnl` isn't _really_ a comment (because parenthesis are still matched inside it), but it's a start.

This is on #316 so presumably other people are also interested in it.