### PR TITLE
add multi_line_comments to VHDL

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1405,6 +1405,7 @@
     "Vhdl": {
       "name": "VHDL",
       "line_comment": ["--"],
+      "multi_line_comments": [["/*", "*/"]],
       "extensions": ["vhd", "vhdl"]
     },
     "VisualBasic": {

--- a/tests/data/vhdl.vhd
+++ b/tests/data/vhdl.vhd
@@ -1,4 +1,8 @@
--- 30 lines 20 code 4 comments 6 blanks
+-- 34 lines 20 code 5 comments 7 blanks
+
+/*
+  Since VHDL 2008 C-Style delimited comment are allowed.
+*/
 
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;

--- a/tests/data/vhdl.vhd
+++ b/tests/data/vhdl.vhd
@@ -1,4 +1,4 @@
--- 34 lines 20 code 5 comments 7 blanks
+-- 34 lines 20 code 7 comments 7 blanks
 
 /*
   Since VHDL 2008 C-Style delimited comment are allowed.


### PR DESCRIPTION
VHDL 2008 introduced C-style delimited comments.
They are described in section [15.9 Comments](https://faculty-web.msoe.edu/johnsontimoj/Common/FILES/VHDL_2008.pdf#page=248)  of IEEE 1076-2008 (IEEE Standard VHDL Language Reference Manual).
