### PR TITLE
[issue_934] from_shebang tera function uses starts_with

### DIFF
--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -380,7 +380,13 @@ impl LanguageType {
                     match word {
                         {% for key, value in languages -%}
                             {%- if value.env -%}
-                                {%- for item in value.env  %}| "{{item}}" {% endfor %}=> Some({{key}}),
+                                {%- for item in value.env  %}
+                                    {% if loop.index == 1 %}
+                                        _ if word.starts_with("{{item}}")
+                                    {% else %}
+                                        || word.starts_with("{{item}}")
+                                    {% endif %}
+                                {% endfor %}=> Some({{key}}),
                             {% endif -%}
                         {%- endfor %}
                         env => {


### PR DESCRIPTION
Fixes #934

This PR allows to cover versioning of language executables, like it can happen for Python. Currently there is `python`, `python2` and `python3` in this language env. Could just add `python2.7`, but we should add new env item for each new Python version, like `python3.4`, `python3.10`, etc. 
This soon may be somewhat cumbersome, so there is a proposition just to match using `starts_with` which should cover such all things. Main drawback is that it could cover things like `pythonxxx`, but not sure if that's a very big problem.

---
It's merely my second touch of **rust** at all (not mentioning the tera), so if there would be some better way to handle that, I'd love to hear that.
