### PR TITLE
Add EBNF support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -9,6 +9,15 @@
       "line_comment": [";"],
       "extensions": ["abnf"]
     },
+    "Ebnf": {
+      "name": "EBNF",
+      "line_comment": [";"],
+      "multi_line_comments": [
+        ["(*", "*)"],
+        ["/*", "*/"]
+      ],
+      "extensions": ["ebnf"]
+    },
     "ActionScript": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],

--- a/languages.json
+++ b/languages.json
@@ -9,15 +9,6 @@
       "line_comment": [";"],
       "extensions": ["abnf"]
     },
-    "Ebnf": {
-      "name": "EBNF",
-      "line_comment": [";"],
-      "multi_line_comments": [
-        ["(*", "*)"],
-        ["/*", "*/"]
-      ],
-      "extensions": ["ebnf"]
-    },
     "ActionScript": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
@@ -366,6 +357,15 @@
       "name": "Dust.js",
       "multi_line_comments": [["{!", "!}"]],
       "extensions": ["dust"]
+    },
+    "Ebnf": {
+      "name": "EBNF",
+      "line_comment": [";"],
+      "multi_line_comments": [
+        ["(*", "*)"],
+        ["/*", "*/"]
+      ],
+      "extensions": ["ebnf"]
     },
     "Ebuild": {
       "line_comment": ["#"],

--- a/tests/data/ebnf.ebnf
+++ b/tests/data/ebnf.ebnf
@@ -1,0 +1,3 @@
+; 3 lines 1 code 2 comments 0 blanks
+whitespace ::= ' ' | #x9 | #xA | #xD
+; l


### PR DESCRIPTION
This PR adds support for EBNF.
The [W3C](https://www.w3.org/Notation.html) uses `;` for single-line comments.
They used `/* ... */` when defining [XML](https://www.w3.org/TR/REC-xml/#sec-notation).
The [ISO](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form#Table_of_symbols) uses `(* ... *)` for comments and `;` for line termination, so this is a bit tricky