### PR TITLE
Add support for Chapel

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -169,6 +169,12 @@
       "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "extensions": ["ceylon"]
     },
+    "Chapel": {
+      "line_comment": ["//"],
+      "multi_line_comments": [["/*", "*/"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["chpl"]
+    },
     "CHeader": {
       "name": "C Header",
       "line_comment": ["//"],

--- a/tests/data/chapel.chpl
+++ b/tests/data/chapel.chpl
@@ -1,0 +1,24 @@
+// chapel 24 lines 9 code 9 comments 6 blanks
+
+// Tidy line comment
+
+/* Tidy block
+   comment.
+*/
+
+// Cheeky line comments /*
+// */
+
+/* Cheeky // block comments */
+
+// Caculate a factorial
+proc factorial(n: int): int {
+    var x = 1; // this will eventually be returned
+    for i in 1..n {
+        x *= i;
+    }
+    return x;
+}
+
+writeln("// this isn't a comment");
+writeln('/* this is also not a comment */');


### PR DESCRIPTION
This commit adds support for [Chapel](https://chapel-lang.org/).

Per [Chapel's documentation] it supports C-style comments and single or double quoted strings.

[Chapel's documentation]: https://chapel-lang.org/docs/language/spec/lexical-structure.html