### PR TITLE
Add Hy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Hex
 Hlsl
 HolyC
 Html
+Hy
 Idris
 Ini
 IntelHex

--- a/languages.json
+++ b/languages.json
@@ -635,6 +635,10 @@
       "mime": ["text/html"],
       "extensions": ["html", "htm"]
     },
+    "Hy": {
+      "line_comment": [";"],
+      "extensions": ["hy"]
+    },
     "Idris": {
       "line_comment": ["--"],
       "multi_line_comments": [["{-", "-}"]],


### PR DESCRIPTION
A dialect of Lisp that's embedded in Python.
More info about the language:

https://hylang.org/