### PR TITLE
Make language entries colorable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@ properties of a language in `languages.json` through examples.
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
       "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
-      "extensions": ["js", "mjs"]
+      "extensions": ["cjs", "js", "mjs"],
+      "color": { "r": 240, "g": 219, "b": 79 }
 },
 ```
 
@@ -123,6 +124,16 @@ detected as a `CMake` file, not a `Text` file.
     "filenames": [
         "cmakelists.txt"
     ]
+},
+```
+
+If a language has a color defined (like for example used in language statistics by git hosting platforms) it can be defined as a RGB-Object.
+
+GitHub uses [linguist](https://github.com/github/linguist) for it's colors so their [color definitions](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml) are a good source to look for a language color.
+
+```json
+"JavaScript": {
+      "color": { "r": 240, "g": 219, "b": 79 }
 },
 ```
 

--- a/languages.json
+++ b/languages.json
@@ -633,7 +633,8 @@
       "kind": "html",
       "important_syntax": ["<script", "<style"],
       "mime": ["text/html"],
-      "extensions": ["html", "htm"]
+      "extensions": ["html", "htm"],
+      "color": {"r": 228, "g": 77, "b": 38}
     },
     "Hy": {
       "line_comment": [";"],
@@ -703,7 +704,8 @@
           "text/x-ecmascript",
           "text/x-javascript"
       ],
-      "extensions": ["cjs", "js", "mjs"]
+      "extensions": ["cjs", "js", "mjs"],
+      "color": { "r": 240, "g": 219, "b": 79 }
     },
     "Jinja2": {
       "name": "Jinja2",
@@ -1334,7 +1336,8 @@
       "multi_line_comments": [["<!--", "-->"]],
       "important_syntax": ["<script", "<style"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "extensions": ["svelte"]
+      "extensions": ["svelte"],
+      "color": { "r": 255, "g": 64, "b": 0 }
     },
     "Svg": {
       "name": "SVG",

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::crate_version;
-use colored::Colorize;
+use colored::{Color, Colorize, ColoredString};
 use num_format::ToFormattedString;
 
 use crate::input::Format;
@@ -173,11 +173,11 @@ impl<W: Write> Printer<W> {
         )
     }
 
-    pub fn print_language(&mut self, language: &Language, name: &str) -> io::Result<()>
+    pub fn print_language(&mut self, language: &Language, name: &str, color: Option<Color>) -> io::Result<()>
     where
         W: Write,
     {
-        self.print_language_name(language.inaccurate, name, None)?;
+        self.print_language_name(language.inaccurate, name, None, color)?;
         write!(self.writer, " ")?;
         writeln!(
             self.writer,
@@ -197,7 +197,7 @@ impl<W: Write> Printer<W> {
     where
         W: Write,
     {
-        self.print_language_name(language.inaccurate, "Total", None)?;
+        self.print_language_name(language.inaccurate, "Total", None, None)?;
         write!(self.writer, " ")?;
         writeln!(
             self.writer,
@@ -272,7 +272,12 @@ impl<W: Write> Printer<W> {
         language_type: LanguageType,
         stats: &[CodeStats],
     ) -> io::Result<()> {
-        self.print_language_name(false, &language_type.to_string(), Some(" |-"))?;
+        self.print_language_name(
+            false,
+            &language_type.to_string(),
+            Some(" |-"),
+            language_type.color(),
+        )?;
         let mut code = 0;
         let mut comments = 0;
         let mut blanks = 0;
@@ -336,7 +341,7 @@ impl<W: Write> Printer<W> {
                     self.print_subrow()?;
                 }
 
-                self.print_language(language, name.name())?;
+                self.print_language(language, name.name(), name.color())?;
                 if has_children {
                     self.print_language_total(language)?;
                 }
@@ -408,7 +413,7 @@ impl<W: Write> Printer<W> {
         stats: &CodeStats,
         inaccurate: bool,
     ) -> io::Result<()> {
-        self.print_language_name(inaccurate, &language_type.to_string(), Some(" |-"))?;
+        self.print_language_name(inaccurate, &language_type.to_string(), Some(" |-"), language_type.color())?;
 
         writeln!(
             self.writer,

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -233,8 +233,14 @@ impl<W: Write> Printer<W> {
         inaccurate: bool,
         name: &str,
         prefix: Option<&str>,
+        language_color: Option<Color>,
     ) -> io::Result<()> {
         let mut lang_section_len = self.columns - NO_LANG_ROW_LEN - prefix.map_or(0, str::len);
+        let colored_name = match language_color {
+            Some(color) => name.color(color),
+            None => ColoredString::from(name),
+        };
+
         if inaccurate {
             lang_section_len -= IDENT_INACCURATE.len();
         }
@@ -244,13 +250,13 @@ impl<W: Write> Printer<W> {
         }
         // truncate and replace the last char with a `|` if the name is too long
         if lang_section_len < name.len() {
-            write!(self.writer, " {:.len$}", name, len = lang_section_len - 1)?;
+            write!(self.writer, " {:.len$}", colored_name, len = lang_section_len - 1)?;
             write!(self.writer, "|")?;
         } else {
             write!(
                 self.writer,
                 " {:<len$}",
-                name.bold(),
+                colored_name.bold(),
                 len = lang_section_len
             )?;
         }

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -1,4 +1,5 @@
 use arbitrary::Arbitrary;
+use colored::Color;
 
 /// Represents a individual programming language. Can be used to provide
 /// information about the language, such as multi line comments, single line
@@ -15,6 +16,14 @@ pub enum LanguageType {
 }
 
 impl LanguageType {
+
+    pub fn color(self) -> Option<Color> {
+        match self {
+            {% for key, value in languages -%}
+                {{key}} => {% if value.color %}Some(Color::TrueColor{r: {{value.color.r}}, g: {{value.color.g}}, b: {{value.color.b}}}){% else %}None{% endif %},
+            {% endfor %}
+        }
+    }
 
     /// Returns the display name of a language.
     ///

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -17,6 +17,14 @@ pub enum LanguageType {
 
 impl LanguageType {
 
+    /// Returns an Option<Color> containing a color associated with the language
+    ///
+    /// ```
+    /// # use tokei::*;
+    /// let svelte = LanguageType::Svelte;
+    ///
+    /// assert_eq!(svelte.color(), Some(Color::TrueColor{ r: 255, g: 64, b: 0 }));
+    /// ```
     pub fn color(self) -> Option<Color> {
         match self {
             {% for key, value in languages -%}


### PR DESCRIPTION
I think having languages colored is a good way of quickly distinguishing them.
So I went ahead and tried to implemented it.

I gave my best to implement it in a way compatible with the project structure.

I already added colors for JavaScript, HTML and Svelte files.
If the code looks good I would also add colors for all the existing languages before merging, I just wanted to confirm the functionality and implementation with a maintainer.
HTML and JavaScript make it possible to manually test if the code is working.

It works by adding a key in the `languages.json`:
`"color": {"r": number, "g": number, "b": number}` and if none is defined it just does not apply any color.

This PR should also close #835.