### PR TITLE
Fix link to speed comparison in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Tokei is a program that displays statistics about your code. Tokei will show the
 ## Features
 
 - Tokei is **very fast**, and is able to count millions of lines of code in seconds.
-  Check out the [12.0.0 release](https://github.com/XAMPPRocky/tokei/releases/v12.0.0)
+  Check out the [11.0.0 release](https://github.com/XAMPPRocky/tokei/releases/v11.0.0)
   to see how Tokei's speed compares to others.
 
 - Tokei is **accurate**, Tokei correctly handles multi line comments,


### PR DESCRIPTION
Readme.md linked to the announcement of version v12.0.0 for a comparison to other implementations when it is actually part of the v11.0.0 announcement.