### PR TITLE
Add arch's PKGBUILD files

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -987,7 +987,7 @@
       "name": "Pacman's makepkg",
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "filenames": ["pkgbuild", ".srcinfo"] 
+      "filenames": ["pkgbuild"] 
     },
     "Pan": {
       "line_comment": ["#"],

--- a/languages.json
+++ b/languages.json
@@ -983,6 +983,12 @@
       "multi_line_comments": [["/*", "*/"]],
       "extensions": ["oz"]
     },
+    "PacmanMakepkg": {
+      "name": "Pacman's makepkg",
+      "line_comment": ["#"],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "filenames": ["pkgbuild", ".srcinfo"] 
+    },
     "Pan": {
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],

--- a/tests/data/PKGBUILD
+++ b/tests/data/PKGBUILD
@@ -1,0 +1,24 @@
+# 24 lines 19 code 3 comments 2 blanks
+# Maintainer: 	  Andy 'Blocktronics' Herbert <blocktronics.org>
+# Aur Maintainer: Wanesty <github.com/Wanesty/aurpkg>
+
+pkgname=moebius-bin
+pkgver=1.0.29
+pkgrel=1
+epoch=1
+pkgdesc="Modern ANSI & ASCII Art Editor"
+arch=('x86_64')
+url="https://github.com/blocktronics/moebius"
+license=('Apache')
+depends=('gtk3' 'libnotify' 'libxss' 'libxtst' 'xdg-utils' 'libappindicator-gtk3')
+makedepends=('libarchive')
+conflicts=('moebius')
+source=("https://github.com/blocktronics/moebius/releases/download/$pkgver/Moebius.rpm") 
+sha256sums=(69aaa1e42e287ed78c8e73971dae3df23ae4fa00e3416ea0fc262b7d147fefec)
+noextract=("Moebius.rpm")
+
+package() {
+	bsdtar -C "${pkgdir}" -xvf "$srcdir/Moebius.rpm"
+	mkdir "$pkgdir/usr/bin"
+	ln -s "/opt/Moebius/moebius" "$pkgdir/usr/bin/moebius"
+}


### PR DESCRIPTION
#888 
> Support for Arch Linux PKGBUILD files

I wanted it too so here it is.

"PacmanMakepkg" could be renamed either "Pacman" or "Makepkg" if you believe the name is too long.