### PR TITLE
Add HiCAD to languages.json

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -613,6 +613,11 @@
       "blank": true,
       "extensions": ["hex"]
     },
+    "HiCad": {
+      "name": "HICAD",
+      "line_comment": ["REM", "rem"],
+      "extensions": ["MAC", "mac"]
+    },
     "Hlsl": {
       "name": "HLSL",
       "line_comment": ["//"],

--- a/tests/data/hicad.mac
+++ b/tests/data/hicad.mac
@@ -1,0 +1,10 @@
+REM 10 lines 4 code 3 comments 3 blanks
+START  59
+
+REM Comment on a line
+%XY:=42
+
+rem This is also a comment
+IF FOO= "foo" GOTO 10
+
+END


### PR DESCRIPTION
Hi @XAMPPRocky

This is for a closed source language specific to a CAD program from [ISD Germany](https://www.isdgroup.com/).
The point in adding this is, I have to maintain a lot of legacy code, and this tool would help me alot.

.mac is very generic I know, but since no one else claimed it yet, it would at least serve my purpose 😄

btw. I added a testfile but have no idea how to test with it, other than well using it, which works.