### PR TITLE
Fix Razor support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1225,8 +1225,11 @@
       "extensions": ["raku", "rakumod", "rakutest", "pm6", "pl6", "p6"]
     },
     "Razor": {
-      "multi_line_comments": [["<!--", "-->"], ["@*", "*@"]],
-      "extensions": ["cshtml"]
+      "line_comment": ["//"],
+      "multi_line_comments": [["<!--", "-->"], ["@*", "*@"], ["/*", "*/"]],
+      "quotes": [["\\\"", "\\\""]],
+      "verbatim_quotes": [["@\\\"", "\\\""]],
+      "extensions": ["cshtml", "razor"]
     },
     "Redscript": {
       "name": "Redscript",

--- a/tests/data/razor.cshtml
+++ b/tests/data/razor.cshtml
@@ -1,0 +1,55 @@
+@* 55 lines 35 code 15 comments 5 blanks *@
+@page "/"
+@using Microsoft.AspNetCore.Components.Web
+@namespace temp.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@{
+    // foo
+    string foo = "bar";
+
+    /*
+    * bar
+    */
+    string bar = "foo";
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="~/" />
+    <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
+    <link href="css/site.css" rel="stylesheet" />
+    <link href="temp.styles.css" rel="stylesheet" />
+    <link rel="icon" type="image/png" href="favicon.png"/>
+    <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+</head>
+<body>
+    @*
+    
+    multi-line comment
+    
+    *@
+    <component type="typeof(App)" render-mode="ServerPrerendered" />
+
+    <div id="blazor-error-ui">
+        <environment include="Staging,Production">
+            An error has occurred. This application may no longer respond until reloaded.
+        </environment>
+        <!--
+        
+        different multi-line comment
+        
+        -->
+        <environment include="Development">
+            An unhandled exception has occurred. See browser dev tools for details.
+        </environment>
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/tests/data/razorcomponent.razor
+++ b/tests/data/razorcomponent.razor
@@ -1,0 +1,45 @@
+@* 45 lines 16 code 21 comments 8 blanks *@
+@page "/counter"
+
+@{
+    // foo
+    string foo = "bar";
+
+    /*
+    * bar
+    */
+    string bar = "foo";
+}
+
+<PageTitle>Counter</PageTitle>
+
+@*
+
+multi-line comment
+
+*@
+<h1>Counter</h1>
+
+<p role="status">Current count: @currentCount</p>
+
+<!--
+
+different multi-line comment
+
+-->
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    /*
+    
+    C# style multi-line comment
+    
+    */
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        // increment the count
+        currentCount++;
+    }
+}


### PR DESCRIPTION
- Adds missing `C#` comments
- Adds missing `C#` quotes
- Adds support for Razor Components (`.razor` files)

Blocks like this will now be counted correctly:

```razor
@{
    // foo
    string foo = "bar";

    /*
    * bar
    */
    string bar = "foo";
}
```

Razor docs: https://learn.microsoft.com/en-us/aspnet/core/mvc/views/razor?view=aspnetcore-7.0