### PR TITLE
Tweak Batch recognition

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -131,8 +131,24 @@
       "extensions": ["bash"]
     },
     "Batch": {
-      "line_comment": ["REM", "::"],
-      "extensions": ["bat", "btm", "cmd"]
+      "line_comment": [
+        "rem",
+        "Rem",
+        "REM",
+        "@rem",
+        "@Rem",
+        "@REM",
+        "&rem",
+        "&Rem",
+        "&REM",
+        "&@rem",
+        "&@Rem",
+        "&@REM",
+        "::",
+        ":::"],
+      "important_syntax": ["::+"],
+      "quotes": [["\\\"", "\\\""]],
+      "extensions": ["bat", "cmd"]
     },
     "Bean": {
       "line_comment": [";"],

--- a/tests/data/batch.cmd
+++ b/tests/data/batch.cmd
@@ -1,0 +1,22 @@
+::+ 22 lines 12 code 4 comments 6 blanks
+
+@if not defined DEBUG (echo off)
+@setlocal DisableDelayedExpansion EnableExtensions
+@goto :main
+
+echo /? Line of code - NOT
+
+::+ Print an argument and add a new line to the output
+:println #[io] (string = "")
+    ::: Echo content to stdout
+    echo(%~1
+
+    goto :EOF &@rem Do not set exit code
+
+:main
+    set "var=Hello world" This is an inline comment that does not get recognized
+
+    @rem Tokenize contents of the variable
+    for /f "usebackq tokens=1,2" %%i in ('%var%') do (
+        call :println "%%~i, %%~j!" 2>nul
+    )


### PR DESCRIPTION
This PR aims to improve recognition of Batch. It:

- removes the `btm` extension as it has nothing to do with Batch (it's actually XML)
- expands definitions of line comments (including permutations of `rem` and command operators in the wild)
- adds doc line comments and quotes
- adds a test file with common comment patterns