### PR TITLE
Remove 'conf' extension from the Bitbake config.

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -167,7 +167,7 @@
       "name": "Bitbake",
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "extensions": ["bb", "bbclass", "bbappend", "inc", "conf"]
+      "extensions": ["bb", "bbclass", "bbappend", "inc"]
     },
     "Bqn": {
       "name": "BQN",


### PR DESCRIPTION
This really can't be claimed by a single language, unless it's an attempt at a "generic" config file format.

This should resolve issue #1000 (as reported by myself).