### PR TITLE
Remove Unnecessary Refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/test
 .tokeirc
 results.csv
 node_modules
+*.code-workspace

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -146,7 +146,7 @@ impl Cli {
                 Arg::new("streaming")
                     .long("streaming")
                     .takes_value(true)
-                    .possible_values(&["simple", "json"])
+                    .possible_values(["simple", "json"])
                     .ignore_case(true)
                     .help(
                         "prints the (language, path, lines, blanks, code, comments) records as \
@@ -158,7 +158,7 @@ impl Cli {
                     .long("sort")
                     .short('s')
                     .takes_value(true)
-                    .possible_values(&["files", "lines", "blanks", "code", "comments"])
+                    .possible_values(["files", "lines", "blanks", "code", "comments"])
                     .ignore_case(true)
                     .conflicts_with("rsort")
                     .help("Sort languages based on column"),
@@ -168,7 +168,7 @@ impl Cli {
                     .long("rsort")
                     .short('r')
                     .takes_value(true)
-                    .possible_values(&["files", "lines", "blanks", "code", "comments"])
+                    .possible_values(["files", "lines", "blanks", "code", "comments"])
                     .ignore_case(true)
                     .conflicts_with("sort")
                     .help("Reverse sort languages based on column"),

--- a/src/input.rs
+++ b/src/input.rs
@@ -224,9 +224,9 @@ mod tests {
         for variant in Format::iter() {
             let serialized = variant
                 .print(&langs)
-                .expect(&format!("Failed serializing variant: {:?}", variant));
+                .unwrap_or_else(|_| panic!("Failed serializing variant: {:?}", variant));
             let deserialized = Format::parse(&serialized)
-                .expect(&format!("Failed deserializing variant: {:?}", variant));
+                .unwrap_or_else(|| panic!("Failed deserializing variant: {:?}", variant));
             assert_eq!(*langs, deserialized);
         }
     }

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -51,7 +51,7 @@ impl LanguageType {
 
         let mut stats = Report::new(path);
 
-        stats += self.parse_from_slice(&text, config);
+        stats += self.parse_from_slice(text, config);
 
         Ok(stats)
     }

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -386,7 +386,7 @@ impl SyntaxCounter {
                     String::from_utf8_lossy(&lines[start_of_code..end_of_code])
                 );
                 let stats =
-                    language.parse_from_slice(&lines[start_of_code..end_of_code].trim(), config);
+                    language.parse_from_slice(lines[start_of_code..end_of_code].trim(), config);
 
                 Some(FileContext::new(
                     LanguageContext::Markdown { balanced, language },
@@ -566,6 +566,7 @@ impl SyntaxCounter {
 
     #[inline]
     pub(crate) fn parse_end_of_quote(&mut self, window: &[u8]) -> Option<usize> {
+        #[allow(clippy::if_same_then_else)]
         if self._is_string_mode() && window.starts_with(self.quote?.as_bytes()) {
             let quote = self.quote.take().unwrap();
             trace!("End {:?}", quote);

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -136,7 +136,7 @@ mod tests {
         language::{languages::Languages, LanguageType},
     };
 
-    const FILE_CONTENTS: &[u8] = &*b"fn main() {}";
+    const FILE_CONTENTS: &[u8] = b"fn main() {}";
     const FILE_NAME: &str = "main.rs";
     const IGNORE_PATTERN: &str = "*.rs";
     const LANGUAGE: &LanguageType = &LanguageType::Rust;
@@ -147,7 +147,7 @@ mod tests {
         let tmp_dir = TempDir::new().expect("Couldn't create temp dir");
         let path_name = tmp_dir.path().join("directory.rs");
 
-        fs::create_dir(&path_name).expect("Couldn't create directory.rs within temp");
+        fs::create_dir(path_name).expect("Couldn't create directory.rs within temp");
 
         super::get_all_files(
             &[tmp_dir.into_path().to_str().unwrap()],


### PR DESCRIPTION
## Changes

- Remove some unnecessary reference.
- Change those `expect()` into `unwrap_or_else(|| panic!())`. (see [Clippy-expect_fun_call](https://rust-lang.github.io/rust-clippy/master/index.html#/expect_fun_call))