### PR TITLE
Update `--languages` Output Format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/test
 .tokeirc
 results.csv
 node_modules
+*.code-workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "c9a577516173adb681466d517d39bd468293bc2c2a16439375ef0f35bba45f3d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -579,6 +579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,7 +838,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -896,9 +905,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -937,9 +946,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1108,7 +1117,7 @@ checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1189,7 +1198,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1201,6 +1210,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "table_formatter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a3ee6ec0d82206e16c1070eee3a5b50c6e276eaabde788e43db61d85d02f989"
+dependencies = [
+ "colored",
+ "itertools",
+ "thiserror",
 ]
 
 [[package]]
@@ -1279,22 +1310,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1352,6 +1383,7 @@ dependencies = [
  "serde_yaml",
  "strum",
  "strum_macros",
+ "table_formatter",
  "tempfile",
  "tera",
  "term_size",
@@ -1536,7 +1568,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -1558,7 +1590,7 @@ checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ once_cell = "1.9"
 regex = "1.5"
 serde_json = "1"
 etcetera = "0.8"
+table_formatter = "0.5.0"
 
 [dependencies.env_logger]
 features = []

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use std::process;
 
 use clap::Arg;
 use clap::{crate_description, ArgMatches};
+use colored::Colorize;
 use tokei::{Config, LanguageType, Sort};
 
 use crate::{
@@ -308,10 +309,60 @@ impl Cli {
         }
     }
 
-    pub fn print_supported_languages() {
-        for (key, extensions) in LanguageType::list() {
-            println!("{} ({})", format!("{}", key), extensions.join(", "));
-        }
+    pub fn print_supported_languages() -> Result<(), Box<dyn std::error::Error>> {
+        use table_formatter::table::*;
+        use table_formatter::{cell, table};
+        let term_width = term_size::dimensions().map(|(w, _)| w).unwrap_or(75) - 8;
+        let (lang_w, suffix_w) = if term_width <= 80 {
+            (term_width / 2, term_width / 2)
+        } else {
+            (40, term_width - 40)
+        };
+
+        let header = vec![
+            cell!(
+                "Language",
+                align = Align::Left,
+                padding = Padding::NONE,
+                width = Some(lang_w)
+            )
+            .with_formatter(vec![Colorize::bold]),
+            cell!(
+                "Extensions",
+                align = Align::Left,
+                padding = Padding::new(3, 0),
+                width = Some(suffix_w)
+            )
+            .with_formatter(vec![Colorize::bold]),
+        ];
+        let content = LanguageType::list()
+            .iter()
+            .map(|(key, ext)| {
+                vec![
+                    // table::TableCell::new(table::Cell::TextCell(key.name().to_string()))
+                    //     .with_width(lang_w),
+                    cell!(key.name()).with_width(Some(lang_w)),
+                    cell!(
+                        if matches!(key, LanguageType::Emojicode) {
+                            ext.join(", ") + "\u{200b}"
+                        } else if ext.is_empty() {
+                            "<None>".to_string()
+                        } else {
+                            ext.join(", ")
+                        },
+                        align = Align::Left,
+                        padding = Padding::new(3, 0),
+                        width = Some(suffix_w)
+                    ),
+                ]
+            })
+            .collect();
+        let t = table!(header - content with Border::ALL);
+
+        let mut render_result = Vec::new();
+        t.render(&mut render_result)?;
+        println!("{}", String::from_utf8(render_result)?);
+        Ok(())
     }
 
     /// Overrides the shared options (See `tokei::Config` for option

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut cli = Cli::from_args();
 
     if cli.print_languages {
-        Cli::print_supported_languages();
+        Cli::print_supported_languages()?;
         process::exit(0);
     }
 


### PR DESCRIPTION
## Changes

### Update `--languages` Output Format

Now it seems like this:

```
──────────────────────────────────────────────────────────────────
| Language                           Extensions                  |
|────────────────────────────────────────────────────────────────|
| ABNF                               abnf                        |
| AWK                                awk                         |
| ABAP                               abap                        |
| ActionScript                       as                          |
| ...                                ...                         |
──────────────────────────────────────────────────────────────────
```

> `EmojiCode` is treated differently, since emojis are usually rendered as two characters, so I add a `\u+200b` to render it correctly.