### PR TITLE
Bug Fix - Cargo Install Error - Updated cli.rs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -326,14 +326,14 @@ impl Cli {
                 padding = Padding::NONE,
                 width = Some(lang_w)
             )
-            .with_formatter(vec![Colorize::bold]),
+            .with_formatter(vec![table_formatter::table::FormatterFunc::Normal(Colorize::bold)]),
             cell!(
                 "Extensions",
                 align = Align::Left,
                 padding = Padding::new(3, 0),
                 width = Some(suffix_w)
             )
-            .with_formatter(vec![Colorize::bold]),
+            .with_formatter(vec![table_formatter::table::FormatterFunc::Normal(Colorize::bold)]),
         ];
         let content = LanguageType::list()
             .iter()


### PR DESCRIPTION
The with_formatter method of Cell expects vec\<FormatterFunc> as argument, earlier code passed vec\<fn> instead, updated as per suggestions from the rust compiler. Solves installation error with Cargo, fixing issue: https://github.com/XAMPPRocky/tokei/issues/1011