### PR TITLE
Tweak Batch recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ Svg
 Swift
 Swig
 SystemVerilog
+Tcc
 Tcl
 Tex
 Text

--- a/languages.json
+++ b/languages.json
@@ -131,8 +131,19 @@
       "extensions": ["bash"]
     },
     "Batch": {
-      "line_comment": ["REM", "::"],
-      "extensions": ["bat", "btm", "cmd"]
+      "name": "Batchfile",
+      "line_comment": [":::",
+        "REM", "&REM", "@REM", "&@REM",
+        "REm", "&REm", "@REm", "&@REm",
+        "ReM", "&ReM", "@ReM", "&@ReM",
+        "Rem", "&Rem", "@Rem", "&@Rem",
+        "rEM", "&rEM", "@rEM", "&@rEM",
+        "rEm", "&rEm", "@rEm", "&@rEm",
+        "reM", "&reM", "@reM", "&@reM",
+        "rem", "&rem", "@rem", "&@rem"
+      ],
+      "quotes": [["\\\"", "\\\""]],
+      "extensions": ["bat", "cmd"]
     },
     "Bazel": {
       "line_comment": ["#"],
@@ -1433,6 +1444,24 @@
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["sv", "svh"]
+    },
+    "Tcc": {
+      "name": "TCC",
+      "line_comment": [":::",
+        "REM", "&REM", "@REM", "&@REM",
+        "REm", "&REm", "@REm", "&@REm",
+        "ReM", "&ReM", "@ReM", "&@ReM",
+        "Rem", "&Rem", "@Rem", "&@Rem",
+        "rEM", "&rEM", "@rEM", "&@rEM",
+        "rEm", "&rEm", "@rEm", "&@rEm",
+        "reM", "&reM", "@reM", "&@reM",
+        "rem", "&rem", "@rem", "&@rem"
+      ],
+      "multi_line_comments": [
+        ["COMMENT", "ENDCOMMENT"]
+      ],
+      "quotes": [["\\\"", "\\\""]],
+      "extensions": ["btm"]
     },
     "Tcl": {
       "name": "TCL",

--- a/tests/data/batch.cmd
+++ b/tests/data/batch.cmd
@@ -1,0 +1,22 @@
+::: 22 lines 12 code 4 comments 6 blanks
+
+@if not defined DEBUG (echo off)
+@setlocal DisableDelayedExpansion EnableExtensions
+@goto :main
+
+echo /? Should be ignored, but isn't
+
+::: Print an argument and add a new line to the output
+:println (string: str = "")
+    ::: Echo content to stdout
+    set /p="%~1" <nul & (call ) & (echo()
+
+    goto :EOF &@REM Do not set exit code
+
+:main
+    set "var=Hello world" This is an inline comment that does not get recognized
+
+    @rem Tokenize contents of the variable
+    for /f "usebackq tokens=1,2" %%i in ('%var%') do (
+        call :println "%%~i, %%~j!" 2>nul
+    )

--- a/tests/data/tcc.btm
+++ b/tests/data/tcc.btm
@@ -1,0 +1,22 @@
+::: 22 lines 11 code 6 comments 5 blanks
+
+@if not defined DEBUG (echo off)
+@setlocal DisableDelayedExpansion EnableExtensions
+@goto :main
+
+COMMENT
+Print an argument and add a new line to the output
+ENDCOMMENT
+:println (string: str = "")
+    ::: Echo content to stdout
+    set /p="%~1" <nul & (call ) & (echo()
+
+    goto :EOF &@REM Do not set exit code
+
+:main
+    set "var=Hello world" This is an inline comment that does not get recognized
+
+    @rem Tokenize contents of the variable
+    for /f "usebackq tokens=1,2" %%i in ('%var%') do (
+        call :println "%%~i, %%~j!" 2>nul
+    )


### PR DESCRIPTION
This PR aims to improve recognition of Batch. It:

- renames the category in order to be consistent with e.g. GitHub
- moves `btm` extension to a separate definition (TCC files - sometimes it's XML though)
- expands definitions of line comments (including permutations of `rem` and command operators in the wild)
- adds quotes
- provides test files with common comment patterns

Previous PR: #997