### PR TITLE
Add .C as a cpp extension and make extensions case-sensitive

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -80,7 +80,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "extensions": ["s"]
+      "extensions": ["s", "S"]
     },
     "Astro": {
       "line_comment": ["//"],
@@ -253,7 +253,7 @@
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
       "verbatim_quotes": [["R\\\"(", ")\\\""]],
-      "extensions": ["cc", "cpp", "cxx", "c++", "pcc", "tpp"]
+      "extensions": ["cc", "cpp", "cxx", "c++", "pcc", "tpp", "C"]
     },
     "CppHeader": {
       "name": "C++ Header",

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -293,7 +293,12 @@ impl LanguageType {
         }
 
         match fsutils::get_extension(entry) {
-            Some(extension) => LanguageType::from_file_extension(extension.as_str()),
+            Some(extension) => {
+                if let Some(language_type) = LanguageType::from_file_extension(extension.as_str()) {
+                    return Some(language_type);
+                }
+                LanguageType::from_file_extension(extension.to_lowercase().as_str())
+            },
             None => LanguageType::from_shebang(&entry),
         }
     }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -117,7 +117,7 @@ pub fn get_all_files<A: AsRef<Path>>(
 }
 
 pub(crate) fn get_extension(path: &Path) -> Option<String> {
-    path.extension().map(|e| e.to_string_lossy().to_lowercase())
+    path.extension().map(|e| e.to_string_lossy().to_string())
 }
 
 pub(crate) fn get_filename(path: &Path) -> Option<String> {

--- a/tests/data/cpp_C.C
+++ b/tests/data/cpp_C.C
@@ -1,0 +1,46 @@
+/* 46 lines 37 code 3 comments 6 blanks */
+
+#include <stdio.h>
+
+// bubble_sort_function
+void bubble_sort(int a[10], int n) {
+  int t;
+  int j = n;
+  int s = 1;
+  while (s > 0) {
+    s = 0;
+    int i = 1;
+    while (i < j) {
+      if (a[i] < a[i - 1]) {
+        t = a[i];
+        a[i] = a[i - 1];
+        a[i - 1] = t;
+        s = 1;
+      }
+      i++;
+    }
+    j--;
+  }
+}
+
+int main() {
+  int a[] = {4, 65, 2, -31, 0, 99, 2, 83, 782, 1};
+  int n = 10;
+  int i = 0;
+
+  printf(R"(Before sorting:\n\n" )");
+  // Single line comment
+  while (i < n) {
+    printf("%d ", a[i]);
+    i++;
+  }
+
+  bubble_sort(a, n);
+
+  printf("\n\nAfter sorting:\n\n");
+  i = 0;
+  while (i < n) {
+    printf("%d ", a[i]);
+    i++;
+  }
+}


### PR DESCRIPTION
# Motivation
It turns out that some projects use capital .C to refer to C++.

This is true for the OpenFoam project which is a widely used open source software for physics simulations.

Although I do not know of other projects that follow this convention it is worth noting that both github and `cloc` recognize the .C extension as a C++ file. This was showed in more detail in this Issue:

https://github.com/XAMPPRocky/tokei/issues/1024

# Implementation

The file `languages.json` contains a list of extensions for each supported language. So adding ".C" should have been enough for this feature. But the code was casting extensions to lowercase, which makes .c and .C indistinguishable. Because of this the `.to_lower` was also removed from the get_extension utility function.

The "to_lower" was probably added for a purpouse. In order to not break functionality I added a second check. If the case sensitive test does not return any result, a second test is done with the to-lower. This will make the code a tiny bit slower, but only when the case-sensitive check fails and will only repeat a rather fast check.

# Testing

Tests are created by the `build.rs` script according to the files present in `tests/data`. In order to test my solution I copied the `tests/data/cpp.cpp` into a file called `tests/data/cpp_C.C`.

Adding this file without modifying the code will cause a failing test, which is what we want. This is mostly a coincidence I think, for some reason the C language summarize blank lines differently than the Cpp summarize.

I think the more appropriate test would be that each of these files also contain the name of the language that they are meant to be as part of the top comment. This would require additional code changes which I think is a bit outside of the scope of this change. I do intend to create a different PR adding this to the tests, if that is ok.

Observation: Since this new file is a copy of an existing one, it does not occupy extra space in the git file-store, since it stores files by content hash.

# Additional considerations

In Windows the file-system is case-insensitive but case-preserving. I believe that this means that the current version of the code will work correctly on windows to identify .C as cpp. But I do not have a windows system to test this on.