### PR TITLE
Fix LD Script language data

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -838,7 +838,6 @@
     },
     "LinkerScript": {
       "name": "LD Script",
-      "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["ld", "lds"]

--- a/languages.json
+++ b/languages.json
@@ -841,7 +841,7 @@
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "extensions": ["lds"]
+      "extensions": ["ld", "lds"]
     },
     "Lisp": {
       "name": "Common Lisp",


### PR DESCRIPTION
This PR fixes the following points for linker scripts support:

- `.ld` file extension is very common ([e.g. Linux kernel](https://github.com/torvalds/linux/blob/master/arch/x86/boot/setup.ld)).
- `//` line comment is now allowed for linker scripts. [The specification](https://ftp.gnu.org/old-gnu/Manuals/ld-2.9.1/html_chapter/ld_3.html) only mentions `/*` and `*/` as comments. And I confirmed ld actually causes an error as follows.
  ```
  error: kernel.ld:4: unknown directive: //
  >>> // hoge
  >>> ^
  ```