### PR TITLE
Optimization: Read only first 128B from the file when searching for shebang

### DIFF
--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     fmt,
     fs::File,
-    io::{self, BufRead, BufReader, Read},
+    io::{self, Read},
     path::{Path, PathBuf},
     str::FromStr,
 };

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -356,16 +356,23 @@ impl LanguageType {
     /// assert_eq!(rust, Some(LanguageType::Rust));
     /// ```
     pub fn from_shebang<P: AsRef<Path>>(entry: P) -> Option<Self> {
-        let file = match File::open(entry) {
-            Ok(file) => file,
-            _ => return None,
-        };
+        // Read at max `READ_LIMIT` bytes from the given file.
+        // A typical shebang line has a length less than 32 characters;
+        // e.g. '#!/bin/bash' - 11B / `#!/usr/bin/env python3` - 22B
+        // It is *very* unlikely the file contains a valid shebang syntax
+        // if we don't find a newline character after searching the first 128B.
+        const READ_LIMIT: usize = 128;
 
-        let mut buf = BufReader::new(file);
-        let mut line = String::new();
-        let _ = buf.read_line(&mut line);
+        let mut file = File::open(entry).ok()?;
+        let mut buf = [0; READ_LIMIT];
 
-        let mut words = line.split_whitespace();
+        let len = file.read(&mut buf).ok()?;
+        let buf = &buf[..len];
+
+        let first_line = buf.split(|b| *b == b'\n').next()?;
+        let first_line = std::str::from_utf8(first_line).ok()?;
+
+        let mut words = first_line.split_whitespace();
         match words.next() {
             {# First match against any shebang paths, and then check if the
                language matches any found in the environment shebang path. #}


### PR DESCRIPTION
Currently, `LanguageType::from_shebang()` uses `BufReader` and `BufRead::read_line()` to fetch the first line of the file.

- `BufReader::new()` allocates 8 KiB of buffer by default
- `BufRead::read_line()` can end up reading the entire file

A typical shebang line ranges from 10 to 30 characters (e.g. `#!/usr/bin/env python3` is only 22B),
and it is *very* unlikely the file contains a valid shebang syntax if we don't find a newline character within the first few dozens of bytes.

This PR modifies the code so that it only reads the first 128B of the file, into the fixed sized `u8` array, without involving the unnecessary `BufReader` and `String`.