### PR TITLE
Adding support for Snakemake

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1343,6 +1343,13 @@
       "multi_line_comments": [["\\\"", "\\\""]],
       "extensions": ["cs.st", "pck.st"]
     },
+    "Snakemake": {
+      "line_comment": ["#"],
+      "doc_quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""], ["'''", "'''"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["smk", "rules"],
+      "filenames": ["snakefile"]
+    },
     "Solidity": {
       "name": "Solidity",
       "line_comment": ["//"],

--- a/tests/data/Snakefile
+++ b/tests/data/Snakefile
@@ -1,0 +1,67 @@
+# 67 lines 50 code 4 comments 13 blanks
+"""
+A sample Snakefile for testing line counting
+"""
+
+SAMPLES = ["A", "B"]
+
+
+# This is a
+# multiline
+# comment
+rule all:
+    input:
+        "plots/quals.svg"
+
+
+'''Sometimes even some
+comments in single quote
+fences.'''
+rule bwa_map:
+    input:
+        "data/genome.fa",  # Inline comments are also supported
+        "data/samples/{sample}.fastq"
+    output:
+        "mapped_reads/{sample}.bam"
+    shell:
+        "bwa mem {input} | samtools view -Sb - > {output}"
+
+
+rule samtools_sort:
+    input:
+        "mapped_reads/{sample}.bam"
+    output:
+        "sorted_reads/{sample}.bam"
+    shell:
+        "samtools sort -T sorted_reads/{wildcards.sample} "
+        "-O bam {input} > {output}"
+
+
+rule samtools_index:
+    input:
+        "sorted_reads/{sample}.bam"
+    output:
+        "sorted_reads/{sample}.bam.bai"
+    shell:
+        "samtools index {input}"
+
+
+rule bcftools_call:
+    input:
+        fa="data/genome.fa",
+        bam=expand("sorted_reads/{sample}.bam", sample=SAMPLES),
+        bai=expand("sorted_reads/{sample}.bam.bai", sample=SAMPLES)
+    output:
+        "calls/all.vcf"
+    shell:
+        "bcftools mpileup -f {input.fa} {input.bam} | "
+        "bcftools call -mv - > {output}"
+
+
+rule plot_quals:
+    input:
+        "calls/all.vcf"
+    output:
+        "plots/quals.svg"
+    script:
+        "scripts/plot-quals.py"


### PR DESCRIPTION
This PR adds support for [Snakemake](https://snakemake.readthedocs.io), which uses a Python-like syntax.