### PR TITLE
fixed language names not showing when in Light mode (light background

### DIFF
--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -250,7 +250,7 @@ impl<W: Write> Printer<W> {
             write!(
                 self.writer,
                 " {:<len$}",
-                name.bold(),
+                name.bold().magenta(),
                 len = lang_section_len
             )?;
         }


### PR DESCRIPTION
Fixes #805
Changed the language names to be coloured in magenta, so it can work in Light mode (white background).
BEFORE
![image](https://github.com/XAMPPRocky/tokei/assets/119881489/3c85bab5-b2fc-4dfc-8439-058eb17c031b)


AFTER:
![image](https://github.com/XAMPPRocky/tokei/assets/119881489/172288d6-5979-4760-ab61-4fb3678ae520)
