### PR TITLE
Add language support for RP2040 PIO ASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Perl
 Perl6
 Pest
 Php
+PioAsm
 Poke
 Polly
 Pony

--- a/languages.json
+++ b/languages.json
@@ -1062,6 +1062,13 @@
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["php"]
     },
+    "PioAsm": {
+      "name": "RP2040 PIO ASM",
+      "line_comment": [";", "//"],
+      "multi_line_comments": [["/*", "*/"]],
+      "important_syntax": ["% c-sdk {"],
+      "extensions": ["pio"]
+    },
     "Poke": {
       "multi_line_comments": [["/*", "*/"]],
       "extensions": ["pk"]

--- a/src/language/embedding.rs
+++ b/src/language/embedding.rs
@@ -19,10 +19,8 @@ pub static END_TEMPLATE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"</template>"#)
 pub static STARTING_MARKDOWN_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r#"```\S+\s"#).unwrap());
 pub static ENDING_MARKDOWN_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r#"```\s?"#).unwrap());
 
-pub static START_PIO_CSDK: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"% c-sdk \{"#).unwrap());
-pub static END_PIO_CSDK: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r#"%}"#).unwrap());
+pub static START_PIO_CSDK: Lazy<Regex> = Lazy::new(|| Regex::new(r#"% c-sdk \{"#).unwrap());
+pub static END_PIO_CSDK: Lazy<Regex> = Lazy::new(|| Regex::new(r#"%}"#).unwrap());
 
 /// A memory of a regex matched.
 /// The values provided by `Self::start` and `Self::end` are in the same space as the

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -183,6 +183,12 @@ impl LanguageType {
                                 // Add all the markdown blobs.
                                 *stats.blobs.entry(language).or_default() += blob;
                             }
+                            LanguageContext::PioAsm { balanced, language } => {
+                                // Add the lines for the code fences.
+                                stats.comments += if balanced { 2 } else { 1 };
+                                // Add the code inside the fence to the stats.
+                                *stats.blobs.entry(language).or_default() += blob;
+                            }
                         }
 
                         // Advance to after the language code and the delimiter..

--- a/tests/data/pioasm.pio
+++ b/tests/data/pioasm.pio
@@ -1,0 +1,29 @@
+; 30 lines 9 code 14 comments 7 blanks
+; test program
+.program hello
+
+; A comment.
+// A C++-style comment
+/* A C-style comment */
+
+/*
+ *
+ * a multiline comment
+ */
+
+loop:
+  pull                  ; pull word from TX FIFO
+  out pins, 1           /* set pins */
+  jmp loop              // jump
+
+% c-sdk {
+/* A dummy function to test pioasm parsing. */
+static inline uint my_cool_function(uint a) {
+  uint ret = a >> 1;
+
+  // a comment in C
+  return ret;
+}
+%}
+
+; a comment after the C code


### PR DESCRIPTION
Adds support for the PIO assembler language for the RP2040, including embedded C code. I have left the "detected" language from the embedded code snippets generic and hard-coded C for now, as it's possible they could add support for other languages (i.e., C++, Python) in the future. To accomplish this, I have included new patterns and language contexts and so on where necessary.

However, I did not know how to handle the fact that it's an error for a `% c-sdk {` to be unterminated by a matching `%}`. At the moment, it simply treats it the same as Markdown--unbalanced is just treated as a valid block. Feedback would be appreciated. Relevant code snippets: [here](https://github.com/willeccles/tokei/blob/22f5408e334c3d447bd9e902a655a6e6e128b104/src/language/syntax.rs#L525-L559) and [here](https://github.com/willeccles/tokei/blob/22f5408e334c3d447bd9e902a655a6e6e128b104/src/language/language_type.rs#L186-L191).