### PR TITLE
Add fypp extension `.fpp` to `languages.json` for Modern Fortran

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -494,7 +494,7 @@
       "name": "FORTRAN Modern",
       "line_comment": ["!"],
       "quotes": [["\\\"", "\\\""]],
-      "extensions": ["f03", "f08", "f90", "f95"]
+      "extensions": ["f03", "f08", "f90", "f95", "fpp"]
     },
     "FreeMarker": {
       "multi_line_comments": [["<#--", "-->"]],


### PR DESCRIPTION
This adds the extension `.fpp` to the Modern Fortran language, which is associated with [Fypp](https://fypp.readthedocs.io/en/stable/fypp.html) metaprogramming files for Fortran. These files have the same syntax as usual free-form Fortran except for the possibility of a `#:` leading character for the "fypp part." Such lines should be considered part of the normal code line count anyway, so no other changes to `languages.json` are needed.