### PR TITLE
Transforming input before reporting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -56,10 +56,9 @@ pub struct Config {
     pub for_each_fn: Option<fn(LanguageType, Report)>,
     #[serde(skip)]
     /// function to transform the file content before analysis
-    pub transform_fn: Option<TransformFn>,
+    pub transform_fn: Option<fn(&[u8]) -> &[u8]>,
 }
 
-type TransformFn = fn(&[u8]) -> &[u8];
 
 impl Config {
     /// Constructs a new `Config` from either `$base/tokei.toml` or

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,12 @@ pub struct Config {
     #[serde(skip)]
     /// adds a closure for each function, e.g., print the result
     pub for_each_fn: Option<fn(LanguageType, Report)>,
+    #[serde(skip)]
+    /// function to transform the file content before analysis
+    pub transform_fn: Option<TransformFn>,
 }
+
+type TransformFn = fn(&[u8]) -> &[u8];
 
 impl Config {
     /// Constructs a new `Config` from either `$base/tokei.toml` or

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -78,16 +78,21 @@ impl LanguageType {
 
         let syntax = SyntaxCounter::new(self);
 
-        if let Some(end) = syntax.shared.important_syntax.find(text).and_then(|m| {
-            // Get the position of the last line before the important
-            // syntax.
-            text[..=m.start()]
-                .iter()
-                .rev()
-                .position(|&c| c == b'\n')
-                .filter(|&p| p != 0)
-                .map(|p| m.start() - p)
-        }) {
+        if let Some(end) = syntax
+            .shared
+            .important_syntax
+            .find(text)
+            .and_then(|m| {
+                // Get the position of the last line before the important
+                // syntax.
+                text[..=m.start()]
+                    .iter()
+                    .rev()
+                    .position(|&c| c == b'\n')
+                    .filter(|&p| p != 0)
+                    .map(|p| m.start() - p)
+            }) 
+        {
             let (skippable_text, rest) = text.split_at(end + 1);
             let is_fortran = syntax.shared.is_fortran;
             let is_literate = syntax.shared.is_literate;

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -25,8 +25,9 @@ include!(concat!(env!("OUT_DIR"), "/language_type.rs"));
 
 impl Serialize for LanguageType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer {
+    where
+        S: serde::Serializer,
+    {
         serializer.serialize_str(self.name())
     }
 }
@@ -63,7 +64,11 @@ impl LanguageType {
 
     /// Parses the bytes provided as the given [`LanguageType`].
     pub fn parse_from_slice<A: AsRef<[u8]>>(self, text: A, config: &Config) -> CodeStats {
-        let text = text.as_ref();
+        let mut text = text.as_ref();
+        let func = config.transform_fn;
+        if let Some(f) = func {
+            text = f(text);
+        };
 
         if self == LanguageType::Jupyter {
             return self
@@ -73,21 +78,16 @@ impl LanguageType {
 
         let syntax = SyntaxCounter::new(self);
 
-        if let Some(end) = syntax
-            .shared
-            .important_syntax
-            .find(text)
-            .and_then(|m| {
-                // Get the position of the last line before the important
-                // syntax.
-                text[..=m.start()]
-                    .iter()
-                    .rev()
-                    .position(|&c| c == b'\n')
-                    .filter(|&p| p != 0)
-                    .map(|p| m.start() - p)
-            })
-        {
+        if let Some(end) = syntax.shared.important_syntax.find(text).and_then(|m| {
+            // Get the position of the last line before the important
+            // syntax.
+            text[..=m.start()]
+                .iter()
+                .rev()
+                .position(|&c| c == b'\n')
+                .filter(|&p| p != 0)
+                .map(|p| m.start() - p)
+        }) {
             let (skippable_text, rest) = text.split_at(end + 1);
             let is_fortran = syntax.shared.is_fortran;
             let is_literate = syntax.shared.is_literate;


### PR DESCRIPTION
Hey there, 

We had the need to sometimes apply some transformations on the content of code files before getting the statistics for them. Right now `tokei` was not really giving us the possibility to do that.

Therefor I did take a look at the code and thought this would be easy to add, without affecting any existing functionality. Would be cool if we could get that integrated into an upcoming version.

What i did is, I added another Config option, which allows to pass a function, which will transform the text content of a file before getting the statistics.

Would love to hear your thoughts, and happy to adapt the feature in a way that might suit the project better.