### PR TITLE
feat: add support for LALRPOP

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -810,6 +810,13 @@
       "env": ["ksh"],
       "extensions": ["ksh"]
     },
+    "Lalrpop": {
+      "name": "LALRPOP",
+      "line_comment": ["//"],
+      "extensions": ["lalrpop"],
+      "quotes": [["\\\"", "\\\""], ["#\\\"", "\\\"#"]],
+      "verbatim_quotes": [["r##\\\"", "\\\"##"], ["r#\\\"", "\\\"#"]]
+    },
     "KvLanguage": {
       "name":"KV Language",
       "line_comment": ["# "],

--- a/tests/data/lalrpop.lalrpop
+++ b/tests/data/lalrpop.lalrpop
@@ -1,0 +1,37 @@
+// 37 lines 26 code 3 comments 8 blanks
+use crate::ast::{ExprSymbol, Opcode};
+use crate::tok9::Tok;
+
+grammar<'input>(input: &'input str);
+
+// line comment
+pub Expr: Box<ExprSymbol<'input>> = { // comment 1
+    Expr r##"verbatim2"## Factor => Box::new(ExprSymbol::Op(<>)),
+    Factor, // comment 2
+};
+
+Factor: Box<ExprSymbol<'input>> = { // comment 3
+    Factor "FactorOp" Term => Box::new(ExprSymbol::Op(<>)),
+    Term,
+};
+
+// comment 4
+
+Term: Box<ExprSymbol<'input>> = {
+    r#"verbatim"# => Box::new(ExprSymbol::NumSymbol(<>)),
+    "(" <Expr> ")"
+};
+
+extern {
+    type Location = usize;
+    type Error = ();
+
+    enum Tok<'input> {
+        r#"verbatim"# => Tok::NumSymbol(<&'input str>),
+        "FactorOp" => Tok::FactorOp(<Opcode>),
+        r##"verbatim2"## => Tok::ExprOp(<Opcode>),
+        "(" => Tok::ParenOpen,
+        ")" => Tok::ParenClose,
+    }
+}
+


### PR DESCRIPTION
[lalrpop](https://github.com/lalrpop/lalrpop) is a parser generator metalanguage for the Rust language.

## Changes:

- Add an entry for LALRPOP in `languages.json` file.
- Add test for LALRPOP file.