### PR TITLE
languages.json: add jinja extension for Jinja2

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -737,7 +737,7 @@
     "Jinja2": {
       "name": "Jinja2",
       "blank": true,
-      "extensions": ["j2"],
+      "extensions": ["j2", "jinja"],
       "multi_line_comments": [["{#", "#}"]]
     },
     "Jq": {


### PR DESCRIPTION
It's also quite common for Jinja2 templates to be called *.jinja; see [GitHub Code Search](https://github.com/search?q=path%3A*.jinja&type=code).