### PR TITLE
Fix slang

### DIFF
--- a/tests/data/slang.slang
+++ b/tests/data/slang.slang
@@ -1,4 +1,4 @@
-// 15 lines 8 code 4 comments 2 blanks
+// 15 lines 8 code 5 comments 2 blanks
 
 Texture2D<float4> in_tex;
 RWTexture2D<float4> out_tex;


### PR DESCRIPTION
#956 added the support, but didn't include the comment with the counts into the count of the comments.

This could've been caught by CI if it was run on Pull Requests.