### PR TITLE
fix: read hidden from config file

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -370,6 +370,7 @@ impl Cli {
     /// higher precedence than options present in config files.
     ///
     /// #### Shared options
+    /// * `hidden`
     /// * `no_ignore`
     /// * `no_ignore_parent`
     /// * `no_ignore_dot`

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,7 @@ impl Config {
             columns: current_dir
                 .columns
                 .or(home_dir.columns.or(conf_dir.columns)),
+            hidden: current_dir.hidden.or(home_dir.hidden.or(conf_dir.hidden)),
             //languages: current_dir.languages.or(conf_dir.languages),
             treat_doc_strings_as_comments: current_dir.treat_doc_strings_as_comments.or(home_dir
                 .treat_doc_strings_as_comments


### PR DESCRIPTION
Previously, setting `hidden = true` in the config file would have no effect. Now it is properly read.

Fixes: #1092