### PR TITLE
Add OpenSCAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ ObjectiveC
 ObjectiveCpp
 OCaml
 Odin
+OpenSCAD
 OpenQASM
 Org
 Oz

--- a/languages.json
+++ b/languages.json
@@ -1045,6 +1045,13 @@
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]]
     },
+    "OpenScad": {
+      "name": "OpenSCAD",
+      "extensions": ["scad"],
+      "line_comment": ["//"],
+      "multi_line_comments": [["/*", "*/"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]]
+    },
     "OpenPolicyAgent": {
       "name": "Open Policy Agent",
       "line_comment": ["#"],

--- a/tests/data/openscad.scad
+++ b/tests/data/openscad.scad
@@ -1,0 +1,34 @@
+//! 34 lines 15 code 16 comments 3 blanks
+// https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Commented_Example_Projects
+// The idea is to twist a translated circle:
+// -
+/*
+	linear_extrude(height = 10, twist = 360, scale = 0)
+	translate([1,0])
+	circle(r = 1);
+*/
+
+module horn(height = 10, radius = 6,
+			twist = 720, $fn = 50)
+{
+	// A centered circle translated by 1xR and
+	// twisted by 360° degrees, covers a 2x(2xR) space.
+	// -
+	radius = radius/4;
+	// De-translate.
+	// -
+	translate([-radius,0])
+	// The actual code.
+	// -
+	linear_extrude(height = height, twist = twist,
+				   scale=0, $fn = $fn)
+	translate([radius,0])
+	circle(r=radius);
+}
+
+translate([3,0])
+mirror()
+horn();
+
+translate([-3,0])
+horn();


### PR DESCRIPTION
OpenSCAD is a software for creating solid 3D CAD objects. 
SCAD stands for "Scripted CAD", where CAD is an acronym for "Computer-Aided Design".

- https://github.com/openscad/openscad
- https://openscad.org/documentation.html#language-reference
