### PR TITLE
Add hledger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Haskell
 Haxe
 Hcl
 Hex
+hledger
 Hlsl
 HolyC
 Html

--- a/languages.json
+++ b/languages.json
@@ -846,6 +846,13 @@
       "nested": true,
       "extensions": ["lean", "hlean"]
     },
+    "Hledger": {
+      "name": "hledger",
+      "line_comment": [";", "#"],
+      "multi_line_comments": [["comment", "end comment"]],
+      "nested": false,
+      "extensions": ["hledger"]
+    },
     "Less": {
       "name": "LESS",
       "line_comment": ["//"],

--- a/tests/data/hledger.hledger
+++ b/tests/data/hledger.hledger
@@ -1,0 +1,18 @@
+# 18 lines 6 code 10 comments 2 blanks
+# a comment
+; another comment
+
+; ^ a blank line
+comment
+account assets             ; Declare valid account names and display order.
+a block comment
+end comment
+
+account assets:savings     ; A subaccount. This one represents a bank account.
+account assets:checking    ; Another. Note, 2+ spaces after the account name.
+account assets:receivable  ; Accounting type is inferred from english names,
+account passifs            ; or declared with a "type" tag, type:L
+account expenses           ; type:X
+                           ; A follow-on comment line, indented.
+account expenses:rent      ; Expense and revenue categories are also accounts.
+                           ; Subaccounts inherit their parent's type.


### PR DESCRIPTION
Hello,

I added the support for hledger (plain text accounting).

I noticed there are some differences between the comment syntax between "hledger" and "ledger", so I limited the extension to ".hledger", which should be hledger only.

hledger: https://hledger.org/1.34/hledger.html?highlight=extension#comments
ledger: https://ledger-cli.org/doc/ledger3.html#Transactions-and-Comments