### PR TITLE
Add templ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ Swift
 Swig
 SystemVerilog
 Tcl
+Templ
 Tex
 Text
 Thrift

--- a/languages.json
+++ b/languages.json
@@ -1526,6 +1526,12 @@
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["tera"]
     },
+    "Templ": {
+      "name": "Templ",
+      "line_comment": ["//"],
+      "multi_line_comments": [["<!--", "-->"], ["/*", "*/"]],
+      "extensions": ["templ", "tmpl", "tpl"]
+    },
     "Tex": {
       "name": "TeX",
       "line_comment": ["%"],

--- a/languages.json
+++ b/languages.json
@@ -1530,7 +1530,7 @@
       "name": "Templ",
       "line_comment": ["//"],
       "multi_line_comments": [["<!--", "-->"], ["/*", "*/"]],
-      "extensions": ["templ", "tmpl", "tpl"]
+      "extensions": ["templ", "tmpl"]
     },
     "Tex": {
       "name": "TeX",

--- a/languages.json
+++ b/languages.json
@@ -1530,6 +1530,8 @@
       "name": "Templ",
       "line_comment": ["//"],
       "multi_line_comments": [["<!--", "-->"], ["/*", "*/"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "important_syntax": ["templ", "script", "css"],
       "extensions": ["templ", "tmpl"]
     },
     "Tex": {

--- a/tests/data/templ.templ
+++ b/tests/data/templ.templ
@@ -1,0 +1,24 @@
+// 24 lines, 13 code, 8 comments, 3 blanks
+package test
+
+templ Foo() {
+	<div id="bar">
+	<!--
+            HTML comments are also allowed.
+        -->
+		<button class={ button() } onClick={ doSomething() }>Baz</button>
+	</div>
+}
+
+/*
+   some css class.
+*/
+css button() {
+	padding: 7px;
+	border-radius: 5px;
+}
+
+// doSomething does something
+script doSomething() {
+    alert("something")
+}


### PR DESCRIPTION
Hello hello,

I added the support for [templ](templ.guide), which a template language for Go, GitHub recently added support for it, so why not add it to tokei 😄  

File extensions:
- `.templ`
- `.tmpl`