### PR TITLE
feat: add SELinux CIL policy source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Cabal
 Cassius
 Ceylon
 CHeader
+Cil
 Clojure
 ClojureC
 ClojureScript

--- a/languages.json
+++ b/languages.json
@@ -194,6 +194,12 @@
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["h"]
     },
+    "Cil": {
+      "name": "CIL (SELinux)",
+      "line_comment": [";"],
+      "quotes": [["\\\"", "\\\""]],
+      "extensions": ["cil"]
+    },
     "Circom": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],

--- a/tests/data/cil.cil
+++ b/tests/data/cil.cil
@@ -1,0 +1,20 @@
+; 20 lines 15 code 3 comments 2 blanks
+;============= etcd_t ==============
+(allow etcd_t proc_sysctl_t (dir (search)))
+(allow etcd_t proc_sysctl_t (file (read open)))
+(allow etcd_t procfs_t (dir (search getattr)))
+(allow etcd_t procfs_t (lnk_file (read)))
+(allow etcd_t self (dir (read open search)))
+(allow etcd_t self (fifo_file (write read)))
+
+;============= kernel_t ==============
+(allow kernel_t bin_t (dir (search)))
+(allow kernel_t bin_t (file (read execute_no_trans open map execute)))
+(allow kernel_t debugfs_t (dir (search)))
+(allow kernel_t device_t (blk_file (create setattr)))
+(allow kernel_t device_t (chr_file (write create setattr)))
+(allow kernel_t self (capability (dac_override mknod)))
+(allow kernel_t self (dir (write add_name search)))
+(allow kernel_t self (file (write create open)))
+
+(filecon "/.extra(/.*)?" any (system_u object_r extra_t (systemLow systemLow)))


### PR DESCRIPTION
Common Intermediate Language is a format of SELinux policy source