### PR TITLE
Fix issue #1141

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ version = "13.0.0-alpha.2"
 all = ["cbor", "yaml"]
 cbor = ["hex", "serde_cbor"]
 default = []
-json = []
 yaml = ["serde_yaml"]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/XAMPPRocky/tokei.git"
 version = "13.0.0-alpha.2"
 
 [features]
-all = ["cbor", "json", "yaml"]
+all = ["cbor", "yaml"]
 cbor = ["hex", "serde_cbor"]
 default = []
 json = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ repository = "https://github.com/XAMPPRocky/tokei.git"
 version = "13.0.0-alpha.2"
 
 [features]
-all = ["cbor", "yaml"]
+all = ["cbor", "json", "yaml"]
 cbor = ["hex", "serde_cbor"]
 default = []
+json = []
 yaml = ["serde_yaml"]
 
 [profile.release]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,6 @@ pub struct Cli {
     pub types: Option<Vec<LanguageType>>,
     pub compact: bool,
     pub number_format: num_format::CustomFormat,
-    pub verbose: u64,
 }
 
 impl Cli {
@@ -312,7 +311,6 @@ impl Cli {
             types,
             compact,
             number_format,
-            verbose,
         };
 
         debug!("CLI Config: {:#?}", cli);

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -111,10 +111,6 @@ impl NumberFormatStyle {
         }
     }
 
-    pub fn all() -> &'static [&'static str] {
-        &["commas", "dots", "plain", "underscores"]
-    }
-
     pub fn get_format(self) -> Result<num_format::CustomFormat, num_format::Error> {
         num_format::CustomFormat::builder()
             .grouping(num_format::Grouping::Standard)

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,12 +1,27 @@
 // Set of common pub consts.
 
+/// Fallback row length
 pub const FALLBACK_ROW_LEN: usize = 81;
 
 // Column widths used for console printing.
+
+/// Language column width
 pub const LANGUAGE_COLUMN_WIDTH: usize = 10;
+
+/// Path column width
 pub const PATH_COLUMN_WIDTH: usize = 80;
+
+/// Files column width
 pub const FILES_COLUMN_WIDTH: usize = 8;
+
+/// Lines column width
 pub const LINES_COLUMN_WIDTH: usize = 12;
+
+/// Code column width
 pub const CODE_COLUMN_WIDTH: usize = 12;
+
+/// Comments column width
 pub const COMMENTS_COLUMN_WIDTH: usize = 12;
+
+/// Blanks column width
 pub const BLANKS_COLUMN_WIDTH: usize = 12;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ mod stats;
 
 pub use self::{
     config::Config,
+    consts::*,
     language::{Language, LanguageType, Languages},
     sort::Sort,
     stats::{find_char_boundary, CodeStats, Report},

--- a/src/utils/ext.rs
+++ b/src/utils/ext.rs
@@ -2,17 +2,12 @@
 
 pub(crate) trait AsciiExt {
     fn is_whitespace(&self) -> bool;
-    fn is_not_line_ending_whitespace(&self) -> bool;
     fn is_line_ending_whitespace(&self) -> bool;
 }
 
 impl AsciiExt for u8 {
     fn is_whitespace(&self) -> bool {
         *self == b' ' || (b'\x09'..=b'\x0d').contains(self)
-    }
-
-    fn is_not_line_ending_whitespace(&self) -> bool {
-        self.is_whitespace() && !self.is_line_ending_whitespace()
     }
 
     fn is_line_ending_whitespace(&self) -> bool {


### PR DESCRIPTION
Summary of fixes:

* ~~Added *empty* `json` feature and included in `all`~~
* Removed unnecessary `Cli.verbose` property
* Removed unnecessary `NumberFormatStyle.all()` method
* Added doc strings for pub constants in `src/consts.rs`
* Exported `self::consts::*` in `src/lib.rs`
* Removed unused `AsciiExt.is_not_line_ending_whitespace()` method