### PR TITLE
Disable legacy Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ authors = ["Erin Power <xampprocky@gmail.com>"]
 build = "build.rs"
 categories = ["command-line-utilities", "development-tools", "visualization"]
 description = "Count your code, quickly."
-edition = "2018"
 homepage = "https://tokei.rs"
 include = [
   "Cargo.lock",
@@ -20,6 +19,8 @@ name = "tokei"
 readme = "README.md"
 repository = "https://github.com/XAMPPRocky/tokei.git"
 version = "13.0.0-alpha.5"
+rust-version = "1.71"
+edition = "2018"
 
 [features]
 all = ["cbor", "yaml"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ readme = "README.md"
 repository = "https://github.com/XAMPPRocky/tokei.git"
 version = "13.0.0-alpha.5"
 rust-version = "1.71"
-edition = "2018"
+edition = "2021"
 
 [features]
 all = ["cbor", "yaml"]
-cbor = ["hex", "serde_cbor"]
+cbor = ["dep:hex", "dep:serde_cbor"]
 default = []
-yaml = ["serde_yaml"]
+yaml = ["dep:serde_yaml"]
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
Cargo makes redundant features for each optional dependency: https://lib.rs/crates/tokei/features#features-dep-implied 
This change hides them. 

I've also bumped edition, since this crate requires a newer Rust anyway (due to [env_logger](https://lib.rs/crates/env_logger/versions)).
