### PR TITLE
Use `OR` operator in Cargo.toml `license` field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = [
   "src/**/*",
 ]
 keywords = ["utility", "cli", "cloc", "lines", "statistics"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 name = "tokei"
 readme = "README.md"
 repository = "https://github.com/XAMPPRocky/tokei.git"


### PR DESCRIPTION
The use of `/` is deprecated, per the Cargo reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields