### PR TITLE
fix: properly detect Autoconf template file

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -112,7 +112,7 @@
     },
     "Autoconf": {
       "line_comment": ["#", "dnl"],
-      "extensions": ["in"]
+      "filenames": ["configure.ac", "configure.in"]
     },
     "Autoit": {
       "line_comment": [";"],


### PR DESCRIPTION
Pattern `*.in` should not be used to detect an Autoconf template file,
since it is a naming convention for any kind of template file that is used to
generate another file sometime during the configure/build process.
For example: `*.pc.in`, `*.h.in`, `Makefile.in`.

Instead, we should use exact filename `configure.ac` or `configure.in`.
See the [Autoconf manual](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/html_node/Writing-Autoconf-Input.html) for details.