### PR TITLE
Add missing extension `fsti` for F*

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -578,7 +578,7 @@
       "quotes": [["\\\"", "\\\""]],
       "line_comment": ["//"],
       "multi_line_comments": [["(*", "*)"]],
-      "extensions": ["fst"]
+      "extensions": ["fst", "fsti"]
     },
     "Futhark": {
       "line_comment": ["--"],


### PR DESCRIPTION
This PR just adds `fsti` to the list of extensions for F*. (while `fst` files are for implementations, `fsti` files are for interfaces)