### PR TITLE
feat: add SELinux policy source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ Sass
 Scala
 Scheme
 Scons
+SeLinuxPolicySourceFile
 Sh
 ShaderLab
 Slang

--- a/languages.json
+++ b/languages.json
@@ -1546,6 +1546,11 @@
       ],
       "filenames": ["sconstruct", "sconscript"]
     },
+    "SeLinuxPolicySourceFile": {
+      "name": "SELinux Policy Source File",
+      "line_comment": ["#"],
+      "extensions": ["te","if","fc"]
+    },
     "Sh": {
       "name": "Shell",
       "shebangs": ["#!/bin/sh"],

--- a/tests/data/selinux.te
+++ b/tests/data/selinux.te
@@ -1,0 +1,20 @@
+# 20 lines 6 code 11 comments 3 blanks
+policy_module(corecommands)
+
+########################################
+#
+# Declarations
+#
+
+#
+# Types with the exec_type attribute are executable files.
+#
+attribute exec_type;
+
+#
+# bin_t is the type of files in the system bin/sbin directories.
+#
+type bin_t alias { ls_exec_t sbin_t };
+typealias bin_t alias { systemd_detect_virt_t systemd_run_exec_t };
+corecmd_executable_file(bin_t)
+dev_associate(bin_t)	#For /dev/MAKEDEV


### PR DESCRIPTION
This PR adds support for the SELinux policy source file type. This type is different from the CIL file type already present in tokei. The three extensions this PR adds (.te, .fc, .if) all have the same comment syntax. 

[A Redhat article about SELinux policy](https://access.redhat.com/articles/6999267) defines the three files as follows:

> The generated policy template contains the following policy files:
> 
> <mypolicy>.te - defines policy rules as well as new types and domains used by your application
> <mypolicy>.fc - contains file context definitions, in other words, instructions for labeling files related to the application
> <mypolicy>.if - contains interfaces, which are policy macros used by other policy modules to interact with this policy