### PR TITLE
Fix alternative output formats

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -158,13 +158,7 @@ impl Cli {
                 Arg::new("output")
                     .long("output")
                     .short('o')
-                    .value_parser(|x: &str| {
-                        if Format::all().contains(&x) {
-                            Ok(x.to_string())
-                        } else {
-                            Err(format!("Invalid output format: {x:?}"))
-                        }
-                    })
+                    .value_parser(Format::from_str)
                     .help(
                         "Outputs Tokei in a specific format. Compile with additional features for \
                         more format support.",


### PR DESCRIPTION
The new value parser introduced in [1] did not parse the option into a `Format`, but rather into a string, thus breaking alternative output formats, as a different type was expected.

Fixes: https://github.com/XAMPPRocky/tokei/issues/1170

[1]: 9627a24c9c53ebb5ded0c297d9221b8d0d331c09 (Fix cargo audit issues (#1137))

---

N.b: Should this be reported as a bug somewhere? Type errors being propagated to runtime sounds like something `clap` should not do.