### PR TITLE
only check tools name from shebang/env

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -37,7 +37,7 @@
       "name": "APL",
       "line_comment": ["⍝"],
       "extensions": ["apl", "aplf", "apls"],
-      "quotes": [["'", "'"]],
+      "quotes": [["'", "'"]]
     },
     "Arduino": {
       "name": "Arduino C++",
@@ -130,7 +130,7 @@
     },
     "AWK": {
       "line_comment": ["#"],
-      "shebangs": ["#!/bin/awk -f"],
+      "shebangs": ["awk"],
       "extensions": ["awk"]
     },
     "Ballerina": {
@@ -143,10 +143,9 @@
     },
     "Bash": {
       "name": "BASH",
-      "shebangs": ["#!/bin/bash"],
+      "shebangs": ["bash"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["bash"],
       "extensions": ["bash"]
     },
     "Batch": {
@@ -228,6 +227,10 @@
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""], ["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "extensions": ["ceylon"]
+    },
+    "Cgi": {
+      "name": "CGI",
+      "extensions": ["cgi"]
     },
     "Chapel": {
       "line_comment": ["//"],
@@ -329,9 +332,8 @@
     },
     "Crystal": {
       "line_comment": ["#"],
-      "shebangs": ["#!/usr/bin/crystal"],
+      "shebangs": ["crystal"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["crystal"],
       "extensions": ["cr"]
     },
     "CSharp": {
@@ -344,9 +346,9 @@
     },
     "CShell": {
       "name": "C Shell",
-      "shebangs": ["#!/bin/csh"],
+      "shebangs": ["csh"],
       "line_comment": ["#"],
-      "env": ["csh"],
+      "filenames": [".cshrc"],
       "extensions": ["csh"]
     },
     "Css": {
@@ -376,10 +378,10 @@
       "extensions": ["cue"]
     },
     "Cython": {
+      "shebangs": ["cython"],
       "line_comment": ["#"],
       "doc_quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""], ["'''", "'''"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["cython"],
       "extensions": ["pyx", "pxd", "pxi"]
     },
     "D": {
@@ -502,9 +504,9 @@
       "extensions": ["elm"]
     },
     "Elvish": {
+      "shebangs": ["elvish"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["elvish"],
       "extensions": ["elv"]
     },
     "EmacsDevEnv": {
@@ -538,10 +540,9 @@
       "extensions": ["fnl"]
     },
     "Fish": {
-      "shebangs": ["#!/bin/fish"],
+      "shebangs": ["fish"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["fish"],
       "extensions": ["fish"]
     },
     "FlatBuffers": {
@@ -683,10 +684,10 @@
       "extensions": ["gql", "graphql"]
     },
     "Groovy": {
+      "shebangs": ["groovy"],
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "env": ["groovy"],
       "extensions": ["groovy", "grt", "gtpl", "gvy"]
     },
     "Gwion": {
@@ -899,8 +900,7 @@
       "extensions": ["ipynb"]
     },
     "Just": {
-      "shebangs": ["#!/usr/bin/env just --justfile"],
-      "env": ["just"],
+      "shebangs": ["just"],
       "line_comment": ["#"],
       "extensions": ["just"],
       "filenames": ["justfile"]
@@ -927,10 +927,9 @@
     },
     "Ksh": {
       "name": "Korn shell",
-      "shebangs": ["#!/bin/ksh"],
+      "shebangs": ["ksh"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["ksh"],
       "extensions": ["ksh"]
     },
     "Lalrpop": {
@@ -1256,11 +1255,11 @@
       "extensions": ["pas"]
     },
     "Perl": {
-      "shebangs": ["#!/usr/bin/perl"],
+      "shebangs": ["perl"],
       "line_comment": ["#"],
       "multi_line_comments": [["=pod", "=cut"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "extensions": ["pl", "pm"]
+      "extensions": ["pl", "pm", "t"]
     },
     "Pest": {
       "line_comment": ["//"],
@@ -1386,10 +1385,10 @@
       "nested": true
     },
     "Python": {
+      "shebangs": ["python"],
       "line_comment": ["#"],
       "doc_quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""], ["'''", "'''"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["python", "python2", "python3"],
       "mime": ["text/x-python"],
       "extensions": ["py", "pyw", "pyi"]
     },
@@ -1425,10 +1424,10 @@
       "extensions": ["r"]
     },
     "Racket": {
+      "shebangs": ["racket"],
       "line_comment": [";"],
       "multi_line_comments": [["#|", "|#"]],
       "nested": true,
-      "env": ["racket"],
       "extensions": ["rkt", "scrbl"]
     },
     "Rakefile": {
@@ -1439,7 +1438,7 @@
       "extensions": ["rake"]
     },
     "Raku": {
-      "shebangs": ["#!/usr/bin/raku", "#!/usr/bin/perl6"],
+      "shebangs": ["raku", "perl6"],
       "line_comment": ["#"],
       "multi_line_comments": [
         ["#`(", ")"],
@@ -1472,7 +1471,6 @@
         ["=begin SYNOPSIS", "=end SYNOPSIS"],
         ["=begin ", "=end "]
       ],
-      "env": ["raku", "perl6"],
       "extensions": ["raku", "rakumod", "rakutest", "pm6", "pl6", "p6"]
     },
     "Razor": {
@@ -1529,10 +1527,10 @@
       "extensions": ["spec"]
     },
     "Ruby": {
+      "shebangs": ["ruby"],
       "line_comment": ["#"],
       "multi_line_comments": [["=begin", "=end"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["ruby"],
       "extensions": ["rb"]
     },
     "RubyHtml": {
@@ -1581,10 +1579,9 @@
     },
     "Sh": {
       "name": "Shell",
-      "shebangs": ["#!/bin/sh"],
+      "shebangs": ["sh"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "env": ["sh"],
       "extensions": ["sh"]
     },
     "ShaderLab": {
@@ -1942,6 +1939,7 @@
     },
     "VimScript": {
       "name": "Vim Script",
+      "filenames": [".vimrc"],
       "line_comment": ["\\\""],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["vim"]
@@ -2029,7 +2027,7 @@
       "extensions": ["zok"]
     },
     "Zsh": {
-      "shebangs": ["#!/bin/zsh"],
+      "shebangs": ["zsh"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["zsh"]


### PR DESCRIPTION
close #1198

This is my first time to write rust code, any comments are welcome.

The original solution is to compare the whole path of shebang line, but the path might be different even for the same tool.

This only check the last word of the application, and check it twice.

The 1st time is do exactly match, then 2nd time to starts_with match.

The starts_with match might match python_abc for Python, but original solution already have that issue for the env check.

The commit also made changes to the languages.json, it remove all the path from shebangs line, and remove all env lines as it not required anymore. Also I made a few changes to the languages definition.

Thanks for your time.