### PR TITLE
Add `cli` default feature to remove unnecessary dependencies from library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,17 @@ edition = "2021"
 [features]
 all = ["cbor", "yaml"]
 cbor = ["dep:hex", "dep:serde_cbor"]
-default = []
+cli = ["dep:clap", "dep:colored", "dep:env_logger", "dep:num-format"]
+default = ["cli"]
 yaml = ["dep:serde_yaml"]
 
 [profile.release]
 lto = "thin"
 panic = "abort"
+
+[[bin]]
+name = "tokei"
+required-features = ["cli"]
 
 [build-dependencies]
 tera = "1.20.0"
@@ -41,8 +46,8 @@ json5 = "0.4.1"
 [dependencies]
 aho-corasick = "1.1.3"
 arbitrary = { version = "1.3.2", features = ["derive"] }
-clap = { version = "4", features = ["cargo", "string", "wrap_help"] }
-colored = "2.1.0"
+clap = { version = "4", optional = true, features = ["cargo", "string", "wrap_help"] }
+colored = { version = "2.1.0", optional = true }
 crossbeam-channel = "0.5.13"
 encoding_rs_io = "0.1.7"
 grep-searcher = "0.1.13"
@@ -54,7 +59,7 @@ term_size = "0.3.2"
 toml = "0.8.19"
 parking_lot = "0.12.3"
 dashmap = { version = "6.0.1", features = ["serde"] }
-num-format = "0.4.4"
+num-format = { version = "0.4.4", optional = true }
 once_cell = "1.19.0"
 regex = "1.10.6"
 serde_json = "1.0.125"
@@ -62,6 +67,7 @@ etcetera = "0.8.0"
 table_formatter = "0.6.1"
 
 [dependencies.env_logger]
+optional = true
 features = []
 version = "0.11.5"
 


### PR DESCRIPTION
Fixes #737

Libraries can disable the `cli` feature using `no-default-features`. The feature is required to build the binary:

```bash
$ cargo run --no-default-features 
error: target `tokei` in package `tokei` requires the features: `cli`
Consider enabling them by passing, e.g., `--features="cli"
```