### PR TITLE
fix: fix failed downcast to NumberFormatStyle when parsing argument

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -213,7 +213,7 @@ impl Cli {
                 Arg::new("num_format_style")
                     .long("num-format")
                     .short('n')
-                    .value_parser(["commas", "dots", "plain", "underscores"])
+                    .value_parser(value_parser!(NumberFormatStyle))
                     .conflicts_with("output")
                     .help(
                         "Format of printed numbers, i.e., plain (1234, default), \


### PR DESCRIPTION
Running: `tokei -n dots .` in the tokei repository fails with the following message:

```
thread 'main' panicked at src\cli.rs:259:14:
Mismatch between definition and access of `num_format_style`. Could not downcast to tokei::cli_utils::NumberFormatStyle, need to downcast to alloc::string::String

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\debug\tokei.exe --num-format dots .` (exit code: 101)
```