### PR TITLE
feat: Column reorder/filter support

### DIFF
--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -119,6 +119,459 @@ impl NumberFormatStyle {
     }
 }
 
+#[derive(Clone, Copy)]
+pub enum Column {
+    Language,
+    Files,
+    Lines,
+    Code,
+    Comments,
+    Blanks,
+}
+
+impl Column {
+    fn print_header(self, mut writer: impl Write) -> io::Result<usize> {
+        let mut len = 0;
+        match self {
+            Column::Language => {
+                let s = "Language";
+                len += s.len();
+                write!(writer, "{}", s.bold().blue())?;
+            }
+            Column::Files => {
+                let s = "Files";
+                len += s.len().max(FILES_COLUMN_WIDTH);
+                write!(writer, "{:>FILES_COLUMN_WIDTH$}", s.bold().blue())?;
+            }
+            Column::Lines => {
+                let s = "Lines";
+                len += s.len().max(LINES_COLUMN_WIDTH);
+                write!(writer, "{:>LINES_COLUMN_WIDTH$}", s.bold().blue())?;
+            }
+            Column::Code => {
+                let s = "Code";
+                len += s.len().max(CODE_COLUMN_WIDTH);
+                write!(writer, "{:>CODE_COLUMN_WIDTH$}", s.bold().blue())?;
+            }
+            Column::Comments => {
+                let s = "Comments";
+                len += s.len().max(COMMENTS_COLUMN_WIDTH);
+                write!(writer, "{:>COMMENTS_COLUMN_WIDTH$}", s.bold().blue(),)?;
+            }
+            Column::Blanks => {
+                let s = "Blanks";
+                len += s.len().max(BLANKS_COLUMN_WIDTH);
+                write!(writer, "{:>BLANKS_COLUMN_WIDTH$}", s.bold().blue())?;
+            }
+        };
+        Ok(len)
+    }
+
+    fn print_language(
+        self,
+        mut writer: impl Write,
+        language: &Language,
+        number_format: &num_format::CustomFormat,
+    ) -> io::Result<usize> {
+        let mut len = 0;
+        match self {
+            Column::Language => unreachable!(),
+            Column::Files => {
+                let s = language.reports.len().to_formatted_string(number_format);
+                len += s.len().max(FILES_COLUMN_WIDTH);
+                write!(writer, "{:>FILES_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Lines => {
+                let s = language.lines().to_formatted_string(number_format);
+                len += s.len().max(LINES_COLUMN_WIDTH);
+                write!(writer, "{:>LINES_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Code => {
+                let s = language.code.to_formatted_string(number_format);
+                len += s.len().max(CODE_COLUMN_WIDTH);
+                write!(writer, "{:>CODE_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Comments => {
+                let s = language.comments.to_formatted_string(number_format);
+                len += s.len().max(COMMENTS_COLUMN_WIDTH);
+                write!(writer, "{:>COMMENTS_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Blanks => {
+                let s = language.blanks.to_formatted_string(number_format);
+                len += s.len().max(BLANKS_COLUMN_WIDTH);
+                write!(writer, "{:>BLANKS_COLUMN_WIDTH$}", s)?;
+            }
+        }
+
+        Ok(len)
+    }
+
+    fn print_language_in_print_total(
+        self,
+        mut writer: impl Write,
+        language: &Language,
+        number_format: &num_format::CustomFormat,
+    ) -> io::Result<usize> {
+        let mut len = 0;
+        match self {
+            Column::Language => unreachable!(),
+            Column::Files => {
+                let s = language
+                    .children
+                    .values()
+                    .map(Vec::len)
+                    .sum::<usize>()
+                    .to_formatted_string(number_format);
+                len += s.len().max(FILES_COLUMN_WIDTH);
+                write!(writer, "{:>FILES_COLUMN_WIDTH$}", s.blue())?;
+            }
+            Column::Lines => {
+                let s = language.lines().to_formatted_string(number_format);
+                len += s.len().max(LINES_COLUMN_WIDTH);
+                write!(writer, "{:>LINES_COLUMN_WIDTH$}", s.blue())?;
+            }
+            Column::Code => {
+                let s = language.code.to_formatted_string(number_format);
+                len += s.len().max(CODE_COLUMN_WIDTH);
+                write!(writer, "{:>CODE_COLUMN_WIDTH$}", s.blue())?;
+            }
+            Column::Comments => {
+                let s = language.comments.to_formatted_string(number_format);
+                len += s.len().max(COMMENTS_COLUMN_WIDTH);
+                write!(writer, "{:>COMMENTS_COLUMN_WIDTH$}", s.blue())?;
+            }
+            Column::Blanks => {
+                let s = language.blanks.to_formatted_string(number_format);
+                len += s.len().max(BLANKS_COLUMN_WIDTH);
+                write!(writer, "{:>BLANKS_COLUMN_WIDTH$}", s.blue())?;
+            }
+        }
+
+        Ok(len)
+    }
+
+    fn print_code_stats(
+        self,
+        mut writer: impl Write,
+        stats: &[CodeStats],
+        number_format: &num_format::CustomFormat,
+        code: usize,
+        comments: usize,
+        blanks: usize,
+    ) -> io::Result<usize> {
+        let mut len = 0;
+        match self {
+            Column::Language => unreachable!(),
+            Column::Files => {
+                let s = stats.len().to_formatted_string(number_format);
+                len += s.len().max(FILES_COLUMN_WIDTH);
+                write!(writer, "{:>FILES_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Lines => {
+                let s = (code + comments + blanks).to_formatted_string(number_format);
+                len += s.len().max(LINES_COLUMN_WIDTH);
+                write!(writer, "{:>LINES_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Code => {
+                let s = code.to_formatted_string(number_format);
+                len += s.len().max(CODE_COLUMN_WIDTH);
+                write!(writer, "{:>CODE_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Comments => {
+                let s = comments.to_formatted_string(number_format);
+                len += s.len().max(COMMENTS_COLUMN_WIDTH);
+                write!(writer, "{:>COMMENTS_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Blanks => {
+                let s = blanks.to_formatted_string(number_format);
+                len += s.len().max(BLANKS_COLUMN_WIDTH);
+                write!(writer, "{:>BLANKS_COLUMN_WIDTH$}", s)?;
+            }
+        }
+
+        Ok(len)
+    }
+
+    fn print_report_total_formatted(
+        self,
+        mut writer: impl Write,
+        name: &str,
+        report: &Report,
+        max_len: usize,
+        number_format: &num_format::CustomFormat,
+    ) -> io::Result<usize> {
+        let mut len = 0;
+        match self {
+            Column::Language => {
+                let s = name;
+                len += s.len().max(max_len);
+                write!(writer, "{:<max_len$}", s)?;
+            }
+            Column::Files => {
+                let s = "";
+                len += s.len().max(FILES_COLUMN_WIDTH);
+                write!(writer, "{:>FILES_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Lines => {
+                let s = report.stats.lines().to_formatted_string(number_format);
+                len += s.len().max(LINES_COLUMN_WIDTH);
+                write!(writer, "{:>LINES_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Code => {
+                let s = report.stats.code.to_formatted_string(number_format);
+                len += s.len().max(CODE_COLUMN_WIDTH);
+                write!(writer, "{:>CODE_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Comments => {
+                let s = report.stats.comments.to_formatted_string(number_format);
+                len += s.len().max(COMMENTS_COLUMN_WIDTH);
+                write!(writer, "{:>COMMENTS_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Blanks => {
+                let s = report.stats.blanks.to_formatted_string(number_format);
+                len += s.len().max(BLANKS_COLUMN_WIDTH);
+                write!(writer, "{:>BLANKS_COLUMN_WIDTH$}", s)?;
+            }
+        }
+
+        Ok(len)
+    }
+
+    fn print_report(
+        self,
+        mut writer: impl Write,
+        stats: &CodeStats,
+        number_format: &num_format::CustomFormat,
+    ) -> io::Result<usize> {
+        let mut len = 0;
+        match self {
+            Column::Language => unreachable!(),
+            Column::Files => {
+                let s = "";
+                len += s.len().max(FILES_COLUMN_WIDTH);
+                write!(writer, "{:>FILES_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Lines => {
+                let s = stats.lines().to_formatted_string(number_format);
+                len += s.len().max(LINES_COLUMN_WIDTH);
+                write!(writer, "{:>LINES_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Code => {
+                let s = stats.code.to_formatted_string(number_format);
+                len += s.len().max(CODE_COLUMN_WIDTH);
+                write!(writer, "{:>CODE_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Comments => {
+                let s = stats.comments.to_formatted_string(number_format);
+                len += s.len().max(COMMENTS_COLUMN_WIDTH);
+                write!(writer, "{:>COMMENTS_COLUMN_WIDTH$}", s)?;
+            }
+            Column::Blanks => {
+                let s = stats.blanks.to_formatted_string(number_format);
+                len += s.len().max(BLANKS_COLUMN_WIDTH);
+                write!(writer, "{:>BLANKS_COLUMN_WIDTH$}", s)?;
+            }
+        }
+
+        Ok(len)
+    }
+}
+
+pub struct RowPrinter<'a> {
+    length: usize,
+    output_columns: &'a [Column],
+    row_start: Vec<u8>,
+    row_end: Vec<u8>,
+    printed_left: usize,
+    printed_right: usize,
+}
+
+impl<'a> RowPrinter<'a> {
+    pub fn new(columns: usize, output_columns: &'a [Column]) -> Self {
+        Self {
+            length: columns,
+            output_columns,
+            row_start: Vec::new(),
+            row_end: Vec::new(),
+            printed_left: 0,
+            printed_right: 0,
+        }
+    }
+
+    pub fn print_header(mut self, writer: impl Write) -> io::Result<()> {
+        self.row_start.push(b' ');
+        self.printed_left = 1 + Column::Language.print_header(&mut self.row_start)?;
+        for col in self.output_columns {
+            self.row_end.push(b' ');
+            self.printed_right += 1 + col.print_header(&mut self.row_end)?;
+        }
+
+        self.write(writer)?;
+        Ok(())
+    }
+
+    pub fn print_language_name(
+        &mut self,
+        inaccurate: bool,
+        name: &str,
+        prefix: Option<&str>,
+    ) -> io::Result<()> {
+        let mut lang_section_len = self.length - NO_LANG_ROW_LEN - prefix.map_or(0, str::len);
+        self.printed_left = lang_section_len + 1; // +1 for initial ' '
+        if inaccurate {
+            lang_section_len -= IDENT_INACCURATE.len();
+        }
+
+        if let Some(prefix) = prefix {
+            write!(&mut self.row_start, "{}", prefix)?;
+            self.printed_left += prefix.len();
+        }
+        // truncate and replace the last char with a `|` if the name is too long
+        if lang_section_len < name.len() {
+            write!(
+                &mut self.row_start,
+                " {:.len$}",
+                name,
+                len = lang_section_len - 1
+            )?;
+            write!(&mut self.row_start, "|")?;
+        } else {
+            write!(
+                &mut self.row_start,
+                " {:<len$}",
+                name.bold().magenta(),
+                len = lang_section_len
+            )?;
+        }
+        if inaccurate {
+            write!(&mut self.row_start, "{}", IDENT_INACCURATE)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn print_language(
+        mut self,
+        writer: impl Write,
+        language: &Language,
+        number_format: &num_format::CustomFormat,
+    ) -> io::Result<()> {
+        for col in self.output_columns {
+            self.row_end.push(b' ');
+            self.printed_right +=
+                1 + col.print_language(&mut self.row_end, language, number_format)?;
+        }
+
+        self.write(writer)?;
+        Ok(())
+    }
+
+    pub fn print_language_in_print_total(
+        mut self,
+        writer: impl Write,
+        language: &Language,
+        number_format: &num_format::CustomFormat,
+    ) -> io::Result<()> {
+        for col in self.output_columns {
+            self.row_end.push(b' ');
+            self.printed_right += 1 + col.print_language_in_print_total(
+                &mut self.row_end,
+                language,
+                number_format,
+            )?;
+        }
+
+        self.write(writer)?;
+        Ok(())
+    }
+
+    pub fn print_code_stats(
+        mut self,
+        writer: impl Write,
+        stats: &[CodeStats],
+        number_format: &num_format::CustomFormat,
+        code: usize,
+        comments: usize,
+        blanks: usize,
+    ) -> io::Result<()> {
+        for col in self.output_columns {
+            self.row_end.push(b' ');
+            self.printed_right += 1 + col.print_code_stats(
+                &mut self.row_end,
+                stats,
+                number_format,
+                code,
+                comments,
+                blanks,
+            )?;
+        }
+
+        self.write(writer)?;
+        Ok(())
+    }
+
+    pub fn print_report_total_formatted(
+        mut self,
+        writer: impl Write,
+        name: Cow<'_, str>,
+        report: &Report,
+        max_len: usize,
+        number_format: &num_format::CustomFormat,
+    ) -> io::Result<()> {
+        for col in self.output_columns {
+            self.row_end.push(b' ');
+            self.printed_right += 1 + col.print_report_total_formatted(
+                &mut self.row_end,
+                &name,
+                report,
+                max_len,
+                number_format,
+            )?;
+        }
+
+        self.row_start.push(b' ');
+        self.printed_left = 1 + Column::Language.print_report_total_formatted(
+            &mut self.row_start,
+            &name,
+            report,
+            max_len.min(self.length - self.printed_right - 2),
+            number_format,
+        )?;
+
+        self.write(writer)?;
+        Ok(())
+    }
+
+    pub fn print_report(
+        mut self,
+        writer: impl Write,
+        stats: &CodeStats,
+        number_format: &num_format::CustomFormat,
+    ) -> io::Result<()> {
+        for col in self.output_columns {
+            self.row_end.push(b' ');
+            self.printed_right += 1 + col.print_report(&mut self.row_end, stats, number_format)?;
+        }
+
+        self.write(writer)?;
+        Ok(())
+    }
+
+    fn write(self, mut writer: impl Write) -> io::Result<()> {
+        let length = self
+            .length
+            .saturating_sub(self.printed_left + self.printed_right + 1);
+        writeln!(
+            writer,
+            "{}{}{:>}",
+            String::from_utf8_lossy(&self.row_start),
+            " ".repeat(length),
+            String::from_utf8_lossy(&self.row_end),
+        )?;
+        Ok(())
+    }
+}
+
 pub struct Printer<W> {
     writer: W,
     columns: usize,
@@ -127,6 +580,7 @@ pub struct Printer<W> {
     subrow: String,
     list_files: bool,
     number_format: num_format::CustomFormat,
+    output_columns: Vec<Column>,
 }
 
 impl<W> Printer<W> {
@@ -135,6 +589,7 @@ impl<W> Printer<W> {
         list_files: bool,
         writer: W,
         number_format: num_format::CustomFormat,
+        output_columns: Vec<Column>,
     ) -> Self {
         Self {
             columns,
@@ -144,6 +599,7 @@ impl<W> Printer<W> {
             row: "━".repeat(columns),
             subrow: "─".repeat(columns),
             number_format,
+            output_columns,
         }
     }
 }
@@ -152,18 +608,9 @@ impl<W: Write> Printer<W> {
     pub fn print_header(&mut self) -> io::Result<()> {
         self.print_row()?;
 
-        let files_column_width: usize = FILES_COLUMN_WIDTH + 6;
-        writeln!(
-            self.writer,
-            " {:<6$} {:>files_column_width$} {:>LINES_COLUMN_WIDTH$} {:>CODE_COLUMN_WIDTH$} {:>COMMENTS_COLUMN_WIDTH$} {:>BLANKS_COLUMN_WIDTH$}",
-            "Language".bold().blue(),
-            "Files".bold().blue(),
-            "Lines".bold().blue(),
-            "Code".bold().blue(),
-            "Comments".bold().blue(),
-            "Blanks".bold().blue(),
-            self.columns - NO_LANG_HEADER_ROW_LEN
-        )?;
+        let printer = RowPrinter::new(self.columns, &self.output_columns);
+        printer.print_header(&mut self.writer)?;
+
         self.print_row()
     }
 
@@ -179,86 +626,20 @@ impl<W: Write> Printer<W> {
     where
         W: Write,
     {
-        self.print_language_name(language.inaccurate, name, None)?;
-        write!(self.writer, " ")?;
-        writeln!(
-            self.writer,
-            "{:>FILES_COLUMN_WIDTH$} {:>LINES_COLUMN_WIDTH$} {:>CODE_COLUMN_WIDTH$} {:>COMMENTS_COLUMN_WIDTH$} {:>BLANKS_COLUMN_WIDTH$}",
-            language
-                .reports
-                .len()
-                .to_formatted_string(&self.number_format),
-            language.lines().to_formatted_string(&self.number_format),
-            language.code.to_formatted_string(&self.number_format),
-            language.comments.to_formatted_string(&self.number_format),
-            language.blanks.to_formatted_string(&self.number_format),
-        )
+        let mut printer = RowPrinter::new(self.columns, &self.output_columns);
+        printer.print_language_name(language.inaccurate, name, None)?;
+        printer.print_language(&mut self.writer, language, &self.number_format)?;
+
+        Ok(())
     }
 
     fn print_language_in_print_total(&mut self, language: &Language) -> io::Result<()>
     where
         W: Write,
     {
-        self.print_language_name(language.inaccurate, "Total", None)?;
-        write!(self.writer, " ")?;
-        writeln!(
-            self.writer,
-            "{:>FILES_COLUMN_WIDTH$} {:>LINES_COLUMN_WIDTH$} {:>CODE_COLUMN_WIDTH$} {:>COMMENTS_COLUMN_WIDTH$} {:>BLANKS_COLUMN_WIDTH$}",
-            language
-                .children
-                .values()
-                .map(Vec::len)
-                .sum::<usize>()
-                .to_formatted_string(&self.number_format)
-                .blue(),
-            language
-                .lines()
-                .to_formatted_string(&self.number_format)
-                .blue(),
-            language
-                .code
-                .to_formatted_string(&self.number_format)
-                .blue(),
-            language
-                .comments
-                .to_formatted_string(&self.number_format)
-                .blue(),
-            language
-                .blanks
-                .to_formatted_string(&self.number_format)
-                .blue(),
-        )
-    }
-
-    pub fn print_language_name(
-        &mut self,
-        inaccurate: bool,
-        name: &str,
-        prefix: Option<&str>,
-    ) -> io::Result<()> {
-        let mut lang_section_len = self.columns - NO_LANG_ROW_LEN - prefix.map_or(0, str::len);
-        if inaccurate {
-            lang_section_len -= IDENT_INACCURATE.len();
-        }
-
-        if let Some(prefix) = prefix {
-            write!(self.writer, "{}", prefix)?;
-        }
-        // truncate and replace the last char with a `|` if the name is too long
-        if lang_section_len < name.len() {
-            write!(self.writer, " {:.len$}", name, len = lang_section_len - 1)?;
-            write!(self.writer, "|")?;
-        } else {
-            write!(
-                self.writer,
-                " {:<len$}",
-                name.bold().magenta(),
-                len = lang_section_len
-            )?;
-        }
-        if inaccurate {
-            write!(self.writer, "{}", IDENT_INACCURATE)?;
-        };
+        let mut printer = RowPrinter::new(self.columns, &self.output_columns);
+        printer.print_language_name(language.inaccurate, "Total", None)?;
+        printer.print_language_in_print_total(&mut self.writer, language, &self.number_format)?;
 
         Ok(())
     }
@@ -268,7 +649,6 @@ impl<W: Write> Printer<W> {
         language_type: LanguageType,
         stats: &[CodeStats],
     ) -> io::Result<()> {
-        self.print_language_name(false, &language_type.to_string(), Some(" |-"))?;
         let mut code = 0;
         let mut comments = 0;
         let mut blanks = 0;
@@ -279,18 +659,20 @@ impl<W: Write> Printer<W> {
             blanks += stats.blanks;
         }
 
+        let mut printer = RowPrinter::new(self.columns, &self.output_columns);
+        printer.print_language_name(false, &language_type.to_string(), Some(" |-"))?;
         if stats.is_empty() {
             Ok(())
         } else {
-            writeln!(
-                self.writer,
-                " {:>FILES_COLUMN_WIDTH$} {:>LINES_COLUMN_WIDTH$} {:>CODE_COLUMN_WIDTH$} {:>COMMENTS_COLUMN_WIDTH$} {:>BLANKS_COLUMN_WIDTH$}",
-                stats.len().to_formatted_string(&self.number_format),
-                (code + comments + blanks).to_formatted_string(&self.number_format),
-                code.to_formatted_string(&self.number_format),
-                comments.to_formatted_string(&self.number_format),
-                blanks.to_formatted_string(&self.number_format),
-            )
+            printer.print_code_stats(
+                &mut self.writer,
+                stats,
+                &self.number_format,
+                code,
+                comments,
+                blanks,
+            )?;
+            Ok(())
         }
     }
 
@@ -359,7 +741,16 @@ impl<W: Write> Printer<W> {
                             let mut first = true;
                             for report in reports.iter() {
                                 if report.stats.blobs.is_empty() {
-                                    writeln!(self.writer, "{:1$}", report, self.path_length)?;
+                                    write!(self.writer, " {}", &report.name.to_string_lossy())?;
+                                    let printer = RowPrinter::new(
+                                        self.columns - report.name.as_os_str().len() - 1,
+                                        &self.output_columns,
+                                    );
+                                    printer.print_report(
+                                        &mut self.writer,
+                                        &report.stats,
+                                        &self.number_format,
+                                    )?;
                                 } else {
                                     if first && a.is_empty() {
                                         writeln!(self.writer, " {}", report.name.display())?;
@@ -376,13 +767,18 @@ impl<W: Write> Printer<W> {
                                             )
                                         )?;
                                     }
-                                    let mut new_report = (*report).clone();
-                                    new_report.name = name.to_string().into();
-                                    writeln!(
-                                        self.writer,
-                                        " |-{:1$}",
-                                        new_report,
-                                        self.path_length - 3
+
+                                    let mut printer =
+                                        RowPrinter::new(self.columns, &self.output_columns);
+                                    printer.print_language_name(
+                                        false,
+                                        &name.to_string(),
+                                        Some(" |-"),
+                                    )?;
+                                    printer.print_report(
+                                        &mut self.writer,
+                                        &report.stats,
+                                        &self.number_format,
                                     )?;
                                     self.print_report_total(report, language.inaccurate)?;
                                 }
@@ -410,17 +806,10 @@ impl<W: Write> Printer<W> {
         stats: &CodeStats,
         inaccurate: bool,
     ) -> io::Result<()> {
-        self.print_language_name(inaccurate, &language_type.to_string(), Some(" |-"))?;
-
-        writeln!(
-            self.writer,
-            " {:>FILES_COLUMN_WIDTH$} {:>LINES_COLUMN_WIDTH$} {:>CODE_COLUMN_WIDTH$} {:>COMMENTS_COLUMN_WIDTH$} {:>BLANKS_COLUMN_WIDTH$}",
-            " ",
-            stats.lines().to_formatted_string(&self.number_format),
-            stats.code.to_formatted_string(&self.number_format),
-            stats.comments.to_formatted_string(&self.number_format),
-            stats.blanks.to_formatted_string(&self.number_format),
-        )
+        let mut printer = RowPrinter::new(self.columns, &self.output_columns);
+        printer.print_language_name(inaccurate, &language_type.to_string(), Some(" |-"))?;
+        printer.print_report(&mut self.writer, stats, &self.number_format)?;
+        Ok(())
     }
 
     fn print_report_total(&mut self, report: &Report, inaccurate: bool) -> io::Result<()> {
@@ -445,14 +834,7 @@ impl<W: Write> Printer<W> {
 
     fn print_report_with_name(&mut self, report: &Report) -> io::Result<()> {
         let name = report.name.to_string_lossy();
-        let name_length = name.len();
 
-        if name_length > self.path_length {
-            let mut formatted = String::from("|");
-            // Add 1 to the index to account for the '|' we add to the output string
-            let from = find_char_boundary(&name, name_length + 1 - self.path_length);
-            formatted.push_str(&name[from..]);
-        }
         self.print_report_total_formatted(name, self.path_length, report)?;
 
         Ok(())
@@ -464,23 +846,15 @@ impl<W: Write> Printer<W> {
         max_len: usize,
         report: &Report,
     ) -> io::Result<()> {
-        let lines_column_width: usize = FILES_COLUMN_WIDTH + 6;
-        writeln!(
-            self.writer,
-            " {: <max$} {:>lines_column_width$} {:>CODE_COLUMN_WIDTH$} {:>COMMENTS_COLUMN_WIDTH$} {:>BLANKS_COLUMN_WIDTH$}",
+        let printer = RowPrinter::new(self.columns, &self.output_columns);
+        printer.print_report_total_formatted(
+            &mut self.writer,
             name,
-            report
-                .stats
-                .lines()
-                .to_formatted_string(&self.number_format),
-            report.stats.code.to_formatted_string(&self.number_format),
-            report
-                .stats
-                .comments
-                .to_formatted_string(&self.number_format),
-            report.stats.blanks.to_formatted_string(&self.number_format),
-            max = max_len
-        )
+            report,
+            max_len,
+            &self.number_format,
+        )?;
+        Ok(())
     }
 
     pub fn print_total(&mut self, languages: &tokei::Languages) -> io::Result<()> {

--- a/src/column.rs
+++ b/src/column.rs
@@ -1,0 +1,57 @@
+use std::{borrow::Cow, str::FromStr};
+
+use serde::de::{self, Deserialize, Deserializer};
+
+/// Used to reorder columns
+#[derive(Clone, Copy, Debug)]
+pub enum Column {
+    /// Indicates the number of files of this type.
+    Files,
+    /// Indicates the total number of lines of text.
+    Lines,
+    /// Indicates the total number of lines of code (excluding whitespace and comments).
+    Code,
+    /// Indicates the number of lines containing comments.
+    Comments,
+    /// Indicates the number of blank or empty lines.
+    Blanks,
+}
+
+impl FromStr for Column {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let col = match s {
+            "files" => Self::Files,
+            "lines" => Self::Lines,
+            "code" => Self::Code,
+            "comments" => Self::Comments,
+            "blanks" => Self::Blanks,
+            _ => return Err(format!("Unknown Column: {}", s)),
+        };
+        Ok(col)
+    }
+}
+
+impl<'de> Deserialize<'de> for Column {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(de::Error::custom)
+    }
+}
+
+impl<'a> From<Column> for Cow<'a, Column> {
+    fn from(from: Column) -> Self {
+        Cow::Owned(from)
+    }
+}
+
+impl<'a> From<&'a Column> for Cow<'a, Column> {
+    fn from(from: &'a Column) -> Self {
+        Cow::Borrowed(from)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::{env, fs, path::PathBuf};
 
 use etcetera::BaseStrategy;
 
+use crate::column::Column;
 use crate::language::LanguageType;
 use crate::sort::Sort;
 use crate::stats::Report;
@@ -47,6 +48,8 @@ pub struct Config {
     /// containing `C`, `Cpp`, and `Rust` with a `Config.types` of `[Cpp, Rust]`
     /// will count only `Cpp` and `Rust`. *Default:* `None`.
     pub types: Option<Vec<LanguageType>>,
+    /// Filter and order what columns should be contained in the output.
+    pub output_columns: Option<Vec<Column>>,
     // /// A map of individual language configuration.
     // pub languages: Option<HashMap<LanguageType, LanguageConfig>>,
     /// Whether to output only the paths for downstream batch processing
@@ -135,6 +138,16 @@ impl Config {
             no_ignore_vcs: current_dir
                 .no_ignore_vcs
                 .or(home_dir.no_ignore_vcs.or(conf_dir.no_ignore_vcs)),
+            output_columns: current_dir
+                .output_columns
+                .or(home_dir.output_columns.or(conf_dir.output_columns))
+                .or(Some(vec![
+                    Column::Files,
+                    Column::Lines,
+                    Column::Code,
+                    Column::Comments,
+                    Column::Blanks,
+                ])),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ extern crate serde;
 
 #[macro_use]
 mod utils;
+mod column;
 mod config;
 mod consts;
 mod language;
@@ -56,6 +57,7 @@ mod sort;
 mod stats;
 
 pub use self::{
+    column::Column,
     config::Config,
     consts::*,
     language::{Language, LanguageType, Languages},

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod input;
 
 use std::{error::Error, io, process};
 
+use cli_utils::Column;
 use tokei::{Config, Languages, Sort};
 
 use crate::{
@@ -90,6 +91,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         cli.files,
         io::BufWriter::new(io::stdout()),
         cli.number_format,
+        vec![
+            Column::Files,
+            Column::Blanks,
+            Column::Comments,
+            Column::Lines,
+            Column::Code,
+        ],
     );
 
     if languages.iter().any(|(_, lang)| lang.inaccurate) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,7 @@ mod input;
 
 use std::{error::Error, io, process};
 
-use cli_utils::Column;
-use tokei::{Config, Languages, Sort};
+use tokei::{Column, Config, Languages, Sort};
 
 use crate::{
     cli::Cli,
@@ -91,13 +90,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         cli.files,
         io::BufWriter::new(io::stdout()),
         cli.number_format,
-        vec![
-            Column::Files,
-            Column::Blanks,
-            Column::Comments,
-            Column::Lines,
-            Column::Code,
-        ],
+        config.output_columns.expect("`output_columns` must be set"),
     );
 
     if languages.iter().any(|(_, lang)| lang.inaccurate) {

--- a/tokei.example.toml
+++ b/tokei.example.toml
@@ -6,3 +6,5 @@ sort = "lines"
 types = ["Python"]
 # Any doc strings (e.g. `"""hello"""` in python) will be counted as comments.
 treat_doc_strings_as_comments = true
+# Filter and reorder output columns.
+output_columns = [ "files", "lines", "code", "comments", "blanks" ]


### PR DESCRIPTION
This PR adds support for reordering and filtering columns in the output.

I added `output_columns` in the config and `--output-columns` as a cli flag for using this feature.

running `tokei --output-columns=files,code,blanks` gives the following output.
![image](https://github.com/user-attachments/assets/1e8639f5-dcf2-4809-a7f5-e4d68ed08d71)

let me know if i missed anything or if you would like me to change something in the PR.