### PR TITLE
Fix a minor typo in CLI help text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,7 +141,7 @@ impl Cli {
                 .action(ArgAction::SetTrue)
                 .help(
                     "\
-                        Don't respect .ignore and .tokeignore files, including this in \
+                        Don't respect .ignore and .tokeignore files, including those in \
                         parent directories.\
                     ",
                 ))


### PR DESCRIPTION
The typo was introduced during the clap v3 migration in 177d32e024b1dfb2b083d74fdbdb97fedd3b93ea.