### PR TITLE
Fix crash when using --num-format

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -256,8 +256,8 @@ impl Cli {
         });
 
         let num_format_style: NumberFormatStyle = matches
-            .get_one::<NumberFormatStyle>("num_format_style")
-            .cloned()
+            .get_one::<String>("num_format_style")
+            .and_then(|s| NumberFormatStyle::from_str(s).ok())
             .unwrap_or_default();
 
         let number_format = match num_format_style.get_format() {


### PR DESCRIPTION
This PR fixes the issue of crashing when using `--num-format` argument due to mismatched type between `NumberFormatStyle` and `String`

**Error** 
```
thread 'main' panicked at src/cli.rs:259:14:
Mismatch between definition and access of `num_format_style`. Could not downcast to tokei::cli_utils::NumberFormatStyle, need to downcast to alloc::string::String
```