### PR TITLE
[CI] fixed broken CI due to deprecated action version

### DIFF
--- a/.github/workflows/mean_bean_ci.yml
+++ b/.github/workflows/mean_bean_ci.yml
@@ -21,7 +21,7 @@ jobs:
           repo: cross
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}

--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -24,7 +24,7 @@ jobs:
           repo: cross
           matches: ${{ matrix.platform }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cross-${{ matrix.platform }}
           path: ${{ steps.cross.outputs.install_path }}


### PR DESCRIPTION
- bump `upload-artifact` from v3 to v4 [[...](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)]