### PR TITLE
Add dtx and ins for TeX/LaTeX

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1762,7 +1762,7 @@
     "Tex": {
       "name": "TeX",
       "line_comment": ["%"],
-      "extensions": ["tex", "sty"]
+      "extensions": ["tex", "sty", "dtx", "ins"]
     },
     "Text": {
       "name": "Plain Text",


### PR DESCRIPTION
- dtx: A documented source file, whose comments can be extracted by DocStrip into another TeX document, and compiled to the PDF manual.
- ins: A installation file that controls DocStrip.

Both files use the same syntax of `*.tex`.

https://texfaq.org/FAQ-dtx

`*.{dtx,ins}` are common in repos that develop LaTeX packages and templates. https://github.com/josephwright/siunitx is an instance.

[Neovim also includes `*.{clo,ltx}` in the list](https://neovim.io/doc/user/syntax/#_tex:~:text=sty%2C%20cls%2C%20clo%2C%20dtx%2C%20or%20ltx), but I've never seen them and I'm not sure if LaTeX is dominant for `*.{clo,ltx}`. Therefore, I only added `*.{dtx,ins}`.


Relates to #1014, which suggests change cls from VB6 to cls.
The cls file can be written by hand, or generated by DocStrip from a dtx file.


---
I submitted [a similar PR to helix](https://github.com/helix-editor/helix/pull/15559), and it has been merged.