### PR TITLE
Add WGSL+Metal to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Makefile
 Markdown
 Mdx
 Meson
+Metal
 Mint
 Mlatu
 ModuleDef
@@ -567,6 +568,7 @@ VisualStudioProject
 VisualStudioSolution
 Vue
 WebAssembly
+WGSL
 Wolfram
 Xaml
 XcodeConfig


### PR DESCRIPTION
Fixes #1136
Adds WGSL and Metal to the readme since they're already supported since `v13.0.0-alpha.0`.
They still aren't listed in the changelog as there isn't a section for `13.0.0-alpha.0`.