### PR TITLE
Update etcetera to 0.9 and then to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,13 +409,13 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "5d14b66eac142247efb8561051ff0fb3d3f58a09801a541b89f46dcc4cc67b84"
 dependencies = [
  "cfg-if",
  "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d14b66eac142247efb8561051ff0fb3d3f58a09801a541b89f46dcc4cc67b84"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
 dependencies = [
  "cfg-if",
  "home",
@@ -1368,6 +1368,7 @@ dependencies = [
  "git2",
  "grep-searcher",
  "hex",
+ "home",
  "ignore",
  "json5",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ num-format = "0.4.4"
 once_cell = "1.19.0"
 regex = "1.10.6"
 serde_json = "1.0.125"
-etcetera = "0.8.0"
+etcetera = "0.9.0"
 table_formatter = "0.6.1"
 
 [dependencies.env_logger]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,11 @@ num-format = "0.4.4"
 once_cell = "1.19.0"
 regex = "1.10.6"
 serde_json = "1.0.125"
-etcetera = "0.9.0"
+etcetera = "0.10.0"
+# Pinning home to <0.5.11 allows etcetera 0.10.0 to have MSRV 1.70 instead of
+# 1.81; see https://github.com/lunacookies/etcetera/releases/tag/v0.10.0. Once
+# our MSRV is at least 1.81, we can remove this direct dependency.
+home = "<0.5.11"
 table_formatter = "0.6.1"
 
 [dependencies.env_logger]


### PR DESCRIPTION
I confirmed that `cargo test --workspace` still passes.