### PR TITLE
Rename Coq to Rocq

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,6 @@ CoffeeScript
 Cogent
 ColdFusion
 ColdFusionScript
-Coq
 Cpp
 CppHeader
 Crystal
@@ -509,6 +508,7 @@ Rakefile
 Razor
 Renpy
 ReStructuredText
+Rocq
 RON
 RPMSpecfile
 Ruby

--- a/languages.json
+++ b/languages.json
@@ -307,11 +307,6 @@
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["cfc"]
     },
-    "Coq": {
-      "quotes": [["\\\"", "\\\""]],
-      "multi_line_comments": [["(*", "*)"]],
-      "extensions": ["v"]
-    },
     "Cpp": {
       "name": "C++",
       "line_comment": ["//"],
@@ -1520,6 +1515,11 @@
       ],
       "doc_quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
       "extensions": ["roc"]
+    },
+     "Rocq": {
+      "quotes": [["\\\"", "\\\""]],
+      "multi_line_comments": [["(*", "*)"]],
+      "extensions": ["v"]
     },
     "RON": {
       "name": "Rusty Object Notation",


### PR DESCRIPTION
The Coq project is now named "The Rocq Prover", see https://rocq-prover.org/changelog/2025-03-12-rocq-9.0