### PR TITLE
hcl: supporto for .tofu extension

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -729,7 +729,7 @@
       "line_comment": ["#", "//"],
       "multi_line_comments": [["/*", "*/"]],
       "quotes": [["\\\"", "\\\""]],
-      "extensions": ["hcl", "tf", "tfvars"]
+      "extensions": ["hcl", "tf", "tfvars", "tofu"]
     },
     "Headache": {
       "line_comment": ["//"],


### PR DESCRIPTION
Opentofu is a fork of terraform supported by Linux Foundation Opentofu supports and suggests using .tofu instead of .tf