### PR TITLE
Add file exntesions for Scheme

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1573,7 +1573,7 @@
       "line_comment": [";"],
       "multi_line_comments": [["#|", "|#"]],
       "nested": true,
-      "extensions": ["scm", "ss"]
+      "extensions": ["sch", "scm", "sld", "ss"]
     },
     "Scons": {
       "line_comment": ["#"],


### PR DESCRIPTION
This PR adds additional file extensions for Scheme.

These file extensions are both used in [Chibi Scheme](https://github.com/ashinn/chibi-scheme). `sch` is identical to `scm`. `sld` is for Scheme library files.