### PR TITLE
Add support for `ClojureDart` language

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -263,6 +263,11 @@
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["cljc"]
     },
+    "ClojureDart": {
+      "line_comment": [";"],
+      "quotes": [["\\\"", "\\\""]],
+      "extensions": ["cljd"]
+    },
     "ClojureScript": {
       "line_comment": [";"],
       "quotes": [["\\\"", "\\\""]],

--- a/tests/data/clojuredart.cljd
+++ b/tests/data/clojuredart.cljd
@@ -1,0 +1,19 @@
+; 19 lines 13 code 3 comments 3 blanks
+
+(ns clojure)
+
+; Below is a function
+(defn a-fn
+  "Docstring with a column ;"
+  [a b]
+  (+ 1 1))
+
+(defn a-fn2
+  ;"Not a doc"
+  "Doc doc again"
+  [a b] ; a and b right?
+  (let [multiline "I'm
+  a multline
+  ; string
+  "]
+       (str multline a b)))


### PR DESCRIPTION
Add support for [ClojureDart](https://github.com/Tensegritics/ClojureDart)

- The extension for ClojureDart is `*.cljd`.
- The test file is identical to those for `*.clj`, `*.cljc`, and `*.cljs`.

If this language is considered too niche, please feel free to close this PR.