### PR TITLE
Classify Containerfiles as Dockerfiles

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -428,8 +428,8 @@
     },
     "Dockerfile": {
       "line_comment": ["#"],
-      "extensions": ["dockerfile", "dockerignore"],
-      "filenames": ["dockerfile"],
+      "extensions": ["dockerfile", "dockerignore", "containerfile", "containerignore"],
+      "filenames": ["dockerfile", "containerfile"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]]
     },
     "DotNetResource": {


### PR DESCRIPTION
- When using `podman`  to run an OCI container it is customary to name the `Dockerfile` as `Containerfile` instead.
This is why I propose that `Containerfile`s should also be classified as `Dockerfile` by tokei as the two are identical for all practical purposes.
- Similarly `podman` also supports `.containerignore` in addition to `.dockerignore`
- I have not added a test as I was not sure if just copying `tests/data/Dockerfile`  to `tests/data/Containerfile` would provide any real value to the project



## Examples of usage of the term `Containerfile` in documentation etc.
- https://docs.podman.io/en/stable/markdown/podman-build.1.html
- https://www.redhat.com/en/blog/write-your-first-containerfile-podman 