### PR TITLE
Fix wrong estimation of code in go

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -699,7 +699,7 @@
     "Go": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""]],
+      "quotes": [["\\\"", "\\\""], ["`", "`"]],
       "extensions": ["go"]
     },
     "Gohtml": {


### PR DESCRIPTION
Tokei was detecting a "/*" in a multiline string "``" as a comment in go.
This makes the rest of the code as a comment too resulting in wrong code and comment count.

Adding multiline string quotes "``" in the 'languages.json' file fixes this.

Example:
```go
package main

import "fmt"

func main() {
    s := `/*`
    fmt.Println(s);
}
```

This resulted in the code count being only 4 lines and comments count being 2 even when there are no comments.

This is the output tokei gave before the change:
<img width="1284" height="350" alt="image" src="https://github.com/user-attachments/assets/a58245ae-6c62-4a16-9ceb-185a249eaa6a" />

This is the output tokei gave after the change:
<img width="1316" height="347" alt="image" src="https://github.com/user-attachments/assets/1b92bb69-436e-4f2d-86b5-31e98f263c10" />
