### PR TITLE
feat: Add C++20 modules support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -327,6 +327,14 @@
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["hh", "hpp", "hxx", "inl", "ipp"]
     },
+    "CppModule": {
+      "name": "C++ Module",
+      "line_comment": ["//"],
+      "multi_line_comments": [["/*", "*/"]],
+      "quotes": [["\\\"", "\\\""]],
+      "verbatim_quotes": [["R\\\"(", ")\\\""]],
+      "extensions": ["cppm", "cxxm", "c++m", "ccm", "ixx"]
+    },
     "Crystal": {
       "line_comment": ["#"],
       "shebangs": ["#!/usr/bin/crystal"],


### PR DESCRIPTION
Add support for c++20 modules.
Extension naming are documented as follows:
[msvc](https://learn.microsoft.com/en-us/cpp/cpp/modules-cpp?view=msvc-170#single-partition-modules)
[clang](https://clang.llvm.org/docs/StandardCPlusPlusModules.html#file-name-requirements)
[gcc](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Modules.html)