### PR TITLE
Add CSV serialization support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,13 +1375,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokei"
-version = "13.0.0-alpha.9"
+version = "13.0.0"
 dependencies = [
  "aho-corasick",
  "arbitrary",
  "clap",
  "colored",
  "crossbeam-channel",
+ "csv",
  "dashmap",
  "encoding_rs_io",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,11 @@ rust-version = "1.71"
 edition = "2021"
 
 [features]
-all = ["cbor", "yaml"]
+all = ["cbor", "yaml", "csv"]
 cbor = ["dep:hex", "dep:serde_cbor"]
 default = []
 yaml = ["dep:serde_yaml"]
+csv = ["dep:csv"]
 
 [profile.release]
 lto = "thin"
@@ -76,6 +77,10 @@ version = "0.11.2"
 [dependencies.serde_yaml]
 optional = true
 version = "0.9.34"
+
+[dependencies.csv]
+optional = true
+version = "1.3.1"
 
 [dev-dependencies]
 proptest = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Tokei is a program that displays statistics about your code. Tokei will show the
 - Tokei has huge range of languages, supporting over **150** languages, and
   their various extensions.
 
-- Tokei can output in multiple formats(**CBOR**, **JSON**, **YAML**)
+- Tokei can output in multiple formats(**CBOR**, **JSON**, **YAML**, **CSV**)
   allowing Tokei's output to be easily stored, and reused. These can also be
   reused in tokei combining a previous run's statistics with another set.
 
@@ -219,12 +219,16 @@ tokei with the features flag.
 
   YAML:
   cargo install tokei --features yaml
+
+  CSV:
+  cargo install tokei --features csv
 ```
 
 **Currently supported formats**
 - JSON `--output json`
 - YAML `--output yaml`
 - CBOR `--output cbor`
+- CSV `--output csv`
 
 ```shell
 $ tokei ./foo --output json
@@ -268,7 +272,7 @@ OPTIONS:
     -i, --input <file_input>      Gives statistics from a previous tokei run. Can be given a file path, or "stdin" to
                                   read from stdin.
     -o, --output <output>         Outputs Tokei in a specific format. Compile with additional features for more format
-                                  support. [possible values: cbor, json, yaml]
+                                  support. [possible values: cbor, json, yaml, csv]
     -s, --sort <sort>             Sort languages based on column [possible values: files, lines, blanks, code, comments]
     -t, --type <types>            Filters output by language type, separated by a comma. i.e. -t=Rust,Markdown
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -319,7 +319,7 @@ impl Cli {
         cli
     }
 
-    pub fn file_input(&self) -> Option<&str> {
+    pub fn file_input(&self) -> Option<String> {
         self.matches.get_one("file_input").cloned()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let config = cli.override_config(Config::from_config_files());
     let mut languages = Languages::new();
 
-    if let Some(input) = cli.file_input() {
+    if let Some(input) = cli.file_input().as_ref() {
         if !add_input(input, &mut languages) {
             Cli::print_input_parse_failure(input);
             process::exit(1);


### PR DESCRIPTION
Using the [csv](https://crates.io/crates/csv) crate, it adds the ability to report the stats in CSV format which is useful for further processing. It flattens the nested `CodeStats` blobs using a `Nesting` column.
It supports both input and output.

It address (at least partially):
- https://github.com/XAMPPRocky/tokei/issues/851
- https://github.com/XAMPPRocky/tokei/issues/558
- https://github.com/XAMPPRocky/tokei/issues/594

There was a previous attempt (cf. https://github.com/XAMPPRocky/tokei/pull/225), but that seemed to stall.

CSV is pretty simple format so the use of csv crate might be a bit of an overkill. OTOH, it makes the code shorter and works well with the `supported_format` macro.