### PR TITLE
Add Avalonia Xaml support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -128,6 +128,12 @@
       "line_comment": ["#"],
       "extensions": ["am"]
     },
+    "AvaloniaXaml": {
+      "name": "AXAML",
+      "multi_line_comments": [["<!--", "-->"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["axaml"]
+    },
     "AWK": {
       "line_comment": ["#"],
       "shebangs": ["#!/bin/awk -f"],


### PR DESCRIPTION
Add support for [Avalonia XAML](https://docs.avaloniaui.net/docs/basics/user-interface/introduction-to-xaml), a dialect of XAML with its own file extension.

Closes [issue](https://github.com/XAMPPRocky/tokei/issues/672)