### PR TITLE
Change name from VB6 to VB6/VBA and add missing VB6 extensions

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1891,9 +1891,9 @@
       "extensions": ["vala"]
     },
     "VB6": {
-      "name": "VB6",
+      "name": "VB6/VBA",
       "line_comment": ["'"],
-      "extensions": ["frm", "bas", "cls"]
+      "extensions": ["frm", "bas", "cls", "ctl", "dsr"]
     },
     "VBScript": {
       "name": "VBScript",


### PR DESCRIPTION
This pull request mainly updates the name of the language for VB6 in the `languages.json` file to VB6/VBA since a large amount of the files with that extension are actually VBA code.

The changes also adds VB6 exclusive extensions (`ctl` and `dsr`) that [github-linguist](https://github.com/github-linguist/linguist/blob/f8e59e555380845b8890d016fdab4c8964a7fec3/lib/linguist/languages.yml#L8118-L8119) also recognizes as VB6.