### PR TITLE
build: Mark term_size, table_formatter and clap-cargo as cli-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,15 @@ edition = "2021"
 [features]
 all = ["cbor", "yaml"]
 cbor = ["dep:hex", "dep:serde_cbor"]
-cli = ["dep:clap", "dep:colored", "dep:env_logger", "dep:num-format"]
+cli = [
+  "dep:clap",
+  "dep:clap-cargo",
+  "dep:colored",
+  "dep:env_logger",
+  "dep:num-format",
+  "dep:table_formatter",
+  "dep:term_size"
+]
 default = ["cli"]
 yaml = ["dep:serde_yaml"]
 
@@ -55,7 +63,7 @@ ignore = "0.4.22"
 log = "0.4.22"
 rayon = "1.10.0"
 serde = { version = "1.0.208", features = ["derive", "rc"] }
-term_size = "0.3.2"
+term_size = { version ="0.3.2", optional = true }
 toml = "0.8.19"
 parking_lot = "0.12.3"
 dashmap = { version = "6.0.1", features = ["serde"] }
@@ -64,8 +72,8 @@ once_cell = "1.19.0"
 regex = "1.10.6"
 serde_json = "1.0.125"
 etcetera = "0.8.0"
-table_formatter = "0.6.1"
-clap-cargo = "0.18.1"
+table_formatter = { version = "0.6.1", optional = true }
+clap-cargo =  { version = "0.18.1", optional = true }
 
 [dependencies.env_logger]
 optional = true


### PR DESCRIPTION
These dependencies are only used in `cli*.rs` or `main.rs`. They are not needed when using tokei as a library.

Context: #1203 #737