### PR TITLE
Fix parsing comments for modern Fortran

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -580,13 +580,13 @@
       ]
     },
     "FortranLegacy": {
-      "name": "FORTRAN Legacy",
+      "name": "Fortran Legacy",
       "line_comment": ["c", "C", "!", "*"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["f", "for", "ftn", "f77", "pfo"]
     },
     "FortranModern": {
-      "name": "FORTRAN Modern",
+      "name": "Fortran Modern",
       "line_comment": ["!"],
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["f03", "f08", "f90", "f95", "fpp"]

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -92,7 +92,7 @@ impl LanguageType {
                 .map(|p| m.start() - p)
         }) {
             let (skippable_text, rest) = text.split_at(end + 1);
-            let is_fortran = syntax.shared.is_fortran;
+            let is_fixed_form_fortran = syntax.shared.is_fixed_form_fortran;
             let is_literate = syntax.shared.is_literate;
             let comments = syntax.shared.line_comments;
             trace!(
@@ -107,7 +107,7 @@ impl LanguageType {
                         // FORTRAN has a rule where it only counts as a comment if it's the
                         // first character in the column, so removing starting whitespace
                         // could cause a miscount.
-                        let line = if is_fortran { line } else { line.trim() };
+                        let line = if is_fixed_form_fortran { line } else { line.trim() };
                         if line.trim().is_empty() {
                             (1, 0, 0)
                         } else if is_literate
@@ -147,7 +147,7 @@ impl LanguageType {
             // FORTRAN has a rule where it only counts as a comment if it's the
             // first character in the column, so removing starting whitespace
             // could cause a miscount.
-            let line = if syntax.shared.is_fortran {
+            let line = if syntax.shared.is_fixed_form_fortran {
                 line
             } else {
                 line.trim()

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -40,8 +40,7 @@ impl LanguageType {
         }
     }
 
-    pub(crate) fn is_fortran(self) -> bool {
-        self == LanguageType::FortranModern ||
+    pub(crate) fn is_fixed_form_fortran(self) -> bool {
         self == LanguageType::FortranLegacy
     }
 

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -72,7 +72,7 @@ pub(crate) struct SharedMatchers {
     pub important_syntax: AhoCorasick,
     #[allow(dead_code)]
     pub any_comments: &'static [&'static str],
-    pub is_fortran: bool,
+    pub is_fixed_form_fortran: bool,
     pub is_literate: bool,
     pub line_comments: &'static [&'static str],
     pub any_multi_line_comments: &'static [(&'static str, &'static str)],
@@ -108,7 +108,7 @@ impl SharedMatchers {
             language,
             allows_nested: language.allows_nested(),
             doc_quotes: language.doc_quotes(),
-            is_fortran: language.is_fortran(),
+            is_fixed_form_fortran: language.is_fixed_form_fortran(),
             is_literate: language.is_literate(),
             important_syntax: init_corasick(language.important_syntax()),
             any_comments: language.any_comments(),

--- a/tests/data/FortranLegacy.f
+++ b/tests/data/FortranLegacy.f
@@ -1,0 +1,7 @@
+*! 7 lines 4 code 3 comments 0 blanks
+      program hello
+!! Just does hello world
+      implicit none
+c another comment
+      print*, "hello world"
+      end program hello

--- a/tests/data/FortranModern.f90
+++ b/tests/data/FortranModern.f90
@@ -1,0 +1,8 @@
+!! 8 lines 4 code 2 comments 2 blanks
+
+program hello
+  !! Just does hello world
+  implicit none
+
+  print*, "hello world"         ! Write hello world
+end program hello


### PR DESCRIPTION
Thanks for this lightning fast tool! I've fixed an issue with Modern Fortran: while legacy (fixed-form) Fortran comments are only in the first column, modern (free-form) doesn't have this limitation.

I've also added very basic tests for the two forms, and corrected a pet peeve: Fortran hasn't been FORTRAN for almost 40 years :)