### PR TITLE
Don't spell Bash in all caps

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -148,7 +148,6 @@
       "extensions": ["bal"]
     },
     "Bash": {
-      "name": "BASH",
       "shebangs": ["#!/bin/bash"],
       "line_comment": ["#"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -20,9 +20,9 @@ impl LanguageType {
     ///
     /// ```
     /// # use tokei::*;
-    /// let bash = LanguageType::Bash;
+    /// let cpp = LanguageType::Cpp;
     ///
-    /// assert_eq!(bash.name(), "BASH");
+    /// assert_eq!(cpp.name(), "C++");
     /// ```
     pub fn name(self) -> &'static str {
         match self {


### PR DESCRIPTION
For example see how its name is written in its [official documentation](https://www.gnu.org/software/bash/manual/bashref.html)