### PR TITLE
Add macro file extension `fnlm` for Fennel

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -541,7 +541,7 @@
     "Fennel" : {
       "line_comment": [";", ";;"],
       "quotes": [["\\\"", "\\\""]],
-      "extensions": ["fnl"]
+      "extensions": ["fnl", "fnlm"]
     },
     "Fish": {
       "shebangs": ["#!/bin/fish"],


### PR DESCRIPTION
Ref: https://fennel-lang.org/reference#import-macros-load-macros-from-a-separate-module