### PR TITLE
Add colors to --help/-h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap-cargo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ae55615695e768a76899c8411b4ebacfbe525e964f94fd24f0007b10b45cd3"
+dependencies = [
+ "anstyle",
+ "clap",
 ]
 
 [[package]]
@@ -219,6 +230,18 @@ dependencies = [
  "clap_lex",
  "strsim",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1354,11 +1377,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokei"
-version = "13.0.0-alpha.9"
+version = "13.0.0"
 dependencies = [
  "aho-corasick",
  "arbitrary",
  "clap",
+ "clap-cargo",
  "colored",
  "crossbeam-channel",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ regex = "1.10.6"
 serde_json = "1.0.125"
 etcetera = "0.8.0"
 table_formatter = "0.6.1"
+clap-cargo = "0.13.0"
 
 [dependencies.env_logger]
 optional = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,7 @@ impl Cli {
         let matches = clap::Command::new("tokei")
             .version(crate_version())
             .author("Erin P. <xampprocky@gmail.com> + Contributors")
+            .styles(clap_cargo::style::CLAP_STYLING)
             .about(concat!(
                 crate_description!(),
                 "\n",


### PR DESCRIPTION
I used [clap-cargo](https://github.com/crate-ci/clap-cargo) as it's easy to use and provides sensible default styles.
User can disable colors via `NO_COLOR=1` environment variable

Output of `tokei -h`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="1808" height="672" alt="tokei-before" src="https://github.com/user-attachments/assets/e16241cf-d5e3-416a-83f1-1f6fa99b349e" /> | <img width="1808" height="672" alt="tokei-colors" src="https://github.com/user-attachments/assets/d4847c24-5c8e-436a-a948-4bbc4fd0e2fc" /> | <img width="1808" height="672" alt="tokei-no-color" src="https://github.com/user-attachments/assets/a53e459a-1cf2-4330-a236-3d6969ebd8d1" /> |
