### PR TITLE
Stop recommending comma-separated CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,11 @@ $ tokei ./foo
 [configuration]: ./tokei.example.toml
 
 #### Multiple folders
-To have tokei report on multiple folders in the same call simply add a comma,
-or a space followed by another path.
+To have tokei report on multiple folders in the same call, simply add all the
+folders you'd like tokei to examine.
 
 ```shell
 $ tokei ./foo ./bar ./baz
-```
-```shell
-$ tokei ./foo, ./bar, ./baz
 ```
 
 #### Excluding folders


### PR DESCRIPTION
The README documents that directory CLI arguments can be comma-separated:

---

#### Multiple folders
To have tokei report on multiple folders in the same call simply add a comma, or a space followed by another path.

```shell
$ tokei ./foo ./bar ./baz
```
```shell
$ tokei ./foo, ./bar, ./baz
```

---

But this doesn't seem to be true:

```shell
jake@Jakes-MBP-2 src % tokei ./foo ./bar ./baz
===============================================================================
 Language            Files        Lines         Code     Comments       Blanks
===============================================================================
 Rust                    3            9            9            0            0
===============================================================================
 Total                   3            9            9            0            0
===============================================================================
```

```shell
jake@Jakes-MBP-2 src % tokei ./foo, ./bar, ./baz
Error: './foo,' not found.
```

Nor does it make very much sense; there could be a directory named `"./foo,"`.

This commit changes the README to stop recommending comma-separated CLI args.