### PR TITLE
Add support for Koka

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Julius
 Just
 KakouneScript
 KaemFile
+Koka
 Kotlin
 Lean
 Less

--- a/languages.json
+++ b/languages.json
@@ -956,6 +956,13 @@
       "line_comment": ["#"],
       "extensions": ["kaem"]
     },
+    "Koka": {
+      "line_comment": ["//"],
+      "multi_line_comments": [["/*", "*/"]],
+      "nested": true,
+      "quotes": [["\\\"", "\\\""]],
+      "extensions": ["kk"]
+    },
     "Kotlin": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],

--- a/tests/data/koka.kk
+++ b/tests/data/koka.kk
@@ -1,0 +1,29 @@
+// 29 lines 11 code 12 comments 6 blanks
+
+/*---------------------------------------------------------------------------
+  Copyright 2020-2021, Microsoft Research, Daan Leijen.
+
+  This is free software; you can redistribute it and/or modify it under the
+  terms of the Apache License, Version 2.0. A copy of the License can be
+  found in the LICENSE file at the root of this distribution.
+---------------------------------------------------------------------------*/
+
+/* Run processes.
+*/
+module std/os/process
+
+import std/os/path
+
+extern import {
+  c file "process-inline.c"
+}
+
+// Run a command in the shell and return its output as a string.
+pub extern run-system-read( cmd : string ) : io error<string> {
+  c "kk_os_run_command_error"
+}
+
+// Run a command in the shell
+pub extern run-system( cmd : string ) : io int {
+  c "kk_os_run_system_prim"
+}


### PR DESCRIPTION
See [Koka](https://koka-lang.github.io/koka/doc/index.html). The test file comes [from the standard library](https://github.com/koka-lang/koka/blob/dev/lib/std/os/process.kk).