### PR TITLE
feat: add diff/patch "languages"

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ DAML
 Dart
 DeviceTree
 Dhall
+Diff
 Dockerfile
 DotNetResource
 DreamMaker

--- a/languages.json
+++ b/languages.json
@@ -453,6 +453,9 @@
       "quotes": [["\\\"", "\\\""], ["''", "''"]],
       "extensions": ["dhall"]
     },
+    "Diff": {
+      "extensions": ["diff", "patch"]
+    },
     "Djot": {
       "literate": true,
       "important_syntax": ["```"],

--- a/src/language/language_type.rs
+++ b/src/language/language_type.rs
@@ -94,6 +94,7 @@ impl LanguageType {
             let (skippable_text, rest) = text.split_at(end + 1);
             let is_fortran = syntax.shared.is_fortran;
             let is_literate = syntax.shared.is_literate;
+            let is_diff = syntax.shared.is_diff;
             let comments = syntax.shared.line_comments;
             trace!(
                 "Using Simple Parse on {:?}",
@@ -107,7 +108,8 @@ impl LanguageType {
                         // FORTRAN has a rule where it only counts as a comment if it's the
                         // first character in the column, so removing starting whitespace
                         // could cause a miscount.
-                        let line = if is_fortran { line } else { line.trim() };
+                        // A leading space in a diff indicates a context line.
+                        let line = if is_fortran || is_diff { line } else { line.trim() };
                         if line.trim().is_empty() {
                             (1, 0, 0)
                         } else if is_literate
@@ -147,7 +149,8 @@ impl LanguageType {
             // FORTRAN has a rule where it only counts as a comment if it's the
             // first character in the column, so removing starting whitespace
             // could cause a miscount.
-            let line = if syntax.shared.is_fortran {
+            // A leading space in a diff indicates a context line.
+            let line = if syntax.shared.is_fortran || syntax.shared.is_diff {
                 line
             } else {
                 line.trim()

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -56,6 +56,10 @@ impl LanguageType {
         }
     }
 
+    pub(crate) fn is_diff(self) -> bool {
+        self == LanguageType::Diff
+    }
+
     /// Provides every variant in a Vec
     pub fn list() -> &'static [(Self, &'static [&'static str])] {
         &[{% for key, val in languages -%}

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -74,6 +74,7 @@ pub(crate) struct SharedMatchers {
     pub any_comments: &'static [&'static str],
     pub is_fortran: bool,
     pub is_literate: bool,
+    pub is_diff: bool,
     pub line_comments: &'static [&'static str],
     pub any_multi_line_comments: &'static [(&'static str, &'static str)],
     pub multi_line_comments: &'static [(&'static str, &'static str)],
@@ -110,6 +111,7 @@ impl SharedMatchers {
             doc_quotes: language.doc_quotes(),
             is_fortran: language.is_fortran(),
             is_literate: language.is_literate(),
+            is_diff: language.is_diff(),
             important_syntax: init_corasick(language.important_syntax()),
             any_comments: language.any_comments(),
             line_comments: language.line_comments(),
@@ -195,6 +197,16 @@ impl SyntaxCounter {
             true
         } else if self.shared.important_syntax.is_match(line) {
             false
+        } else if self.shared.is_diff {
+            if ![" ", "#", "---", "+++"].iter().any(|start| line.starts_with(start.as_bytes())) {
+                stats.code += 1;
+                trace!("Code No.{}", stats.code);
+            } else {
+                stats.comments += 1;
+                trace!("Comment No.{}", stats.comments);
+            }
+
+            true
         } else {
             trace!("^ Skippable");
 

--- a/tests/data/patch.patch
+++ b/tests/data/patch.patch
@@ -1,0 +1,67 @@
+# 67 lines 30 code 30 comments 7 blanks
+From 6c71dd734f0788fb88e116c43a03163929c2aa57 Mon Sep 17 00:00:00 2001
+From: Ben Beasley <code@musicinmybrain.net>
+Date: Mon, 12 Jan 2026 21:27:49 +0000
+Subject: [PATCH] Update strum/strum_macros to 0.27.2 (#1316)
+
+---
+ Cargo.lock | 15 ++++-----------
+ Cargo.toml |  4 ++--
+ 2 files changed, 6 insertions(+), 13 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 961422fc134e29eaf3e221b9c6f0f4c85679cf7e..a2b40a2ec329f9a3138db16d9024af5534031905 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1096,12 +1096,6 @@ dependencies = [
+  "windows-sys 0.52.0",
+ ]
+ 
+-[[package]]
+-name = "rustversion"
+-version = "1.0.17"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+-
+ [[package]]
+ name = "rusty-fork"
+ version = "0.3.0"
+@@ -1246,20 +1240,19 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+ 
+ [[package]]
+ name = "strum"
+-version = "0.26.3"
++version = "0.27.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
++checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+ 
+ [[package]]
+ name = "strum_macros"
+-version = "0.26.4"
++version = "0.27.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
++checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+ dependencies = [
+  "heck",
+  "proc-macro2",
+  "quote",
+- "rustversion",
+  "syn",
+ ]
+ 
+diff --git a/Cargo.toml b/Cargo.toml
+index 076f6e9c4e57a1ddff46f253212e7e2d656cd2c0..8b195223d0831baf3b64952e4a7667d9b21edeba 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -86,7 +86,7 @@ version = "0.9.34"
+ 
+ [dev-dependencies]
+ proptest = "1.5.0"
+-strum = "0.26.3"
+-strum_macros = "0.26.4"
++strum = "0.27.2"
++strum_macros = "0.27.2"
+ tempfile = "3.12.0"
+ git2 = { version = "0.19.0", default-features = false, features = [] }


### PR DESCRIPTION
My goal was to match `cloc`, which explains their methodology at https://github.com/AlDanial/cloc/blob/00ff5f1fbc84348ac45fb2841fd4c1274a02cfb0/cloc#L10303.

Basically, lines starting with a space are context, and these are counted as comments. Lines starting with "#", "---", or "+++" are also considered comments. Blank lines are counted as blanks. All other lines are patched lines, which are counted as code.