### PR TITLE
Add separate Luau language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Lisp
 LLVM
 Logtalk
 Lua
+Luau
 Lucius
 M1Assembly
 Madlang

--- a/languages.json
+++ b/languages.json
@@ -1084,7 +1084,14 @@
       "line_comment": ["--"],
       "multi_line_comments": [["--[[", "]]"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "extensions": ["lua", "luau"]
+      "extensions": ["lua"]
+    },
+    "Luau": {
+      "line_comment": ["--"],
+      "multi_line_comments": [["--[[", "]]"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
+      "verbatim_quotes": [["[[", "]]"]],
+      "extensions": ["luau"]
     },
     "Lucius": {
       "line_comment": ["//"],

--- a/tests/data/luau.luau
+++ b/tests/data/luau.luau
@@ -1,0 +1,20 @@
+-- 20 lines 11 code 5 comments 4 blanks
+
+-- Single-line comment
+--[[
+multiline comment with "quotes" and `backticks`
+]]
+
+local _single = 'single quoted'
+local _double = "double quoted"
+local _name = "Luau"
+
+local _longString = [[
+line one
+line two
+]]
+
+local _interpolated = `hello {_name}`
+local _multiline = `welcome {
+    _name
+}!`


### PR DESCRIPTION
Previously, files with the `.luau` extension were treated as `.lua` files. The Luau language has detached pretty far from its Lua beginnings, adding features such as a native type system. It also has string syntax that should be modeled directly for correct counting that isn't valid in Lua, such as string interpolation.

It also doesn't have one-to-one compatibility with Lua code, which is enumerated [here](https://luau.org/compatibility/).