### PR TITLE
feat: Add Starlark language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ SpecmanE
 Spice
 Sql
 SRecode
+Starlark
 Stata
 Stratego
 Svelte

--- a/languages.json
+++ b/languages.json
@@ -1738,6 +1738,12 @@
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["stan"]
     },
+    "Starlark": {
+      "line_comment": ["#"],
+      "doc_quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["star", "fizz"]
+    },
     "Stata": {
       "line_comment": ["//", "*"],
       "multi_line_comments": [["/*", "*/"]],

--- a/tests/data/starlark.star
+++ b/tests/data/starlark.star
@@ -1,0 +1,20 @@
+# 20 lines 13 code 3 comments 4 blanks
+
+# Load a dependency
+load("@rules_go//go:def.bzl", "go_binary")
+
+# Define a build rule
+def my_binary(name, srcs):
+    go_binary(
+        name = name,
+        srcs = srcs,
+        deps = [
+            "//lib:mylib",
+        ],
+    )
+
+"""
+This is a docstring.
+"""
+
+my_binary(name = "hello", srcs = ["main.go"])


### PR DESCRIPTION
## Summary

- Adds **Starlark** language detection for `.star` and `.fizz` file extensions
- `.fizz` is the extension used by [FizzBee](https://fizzbee.io/), a formal modelling tool that uses Starlark/Python-like syntax
- Includes `#` line comments and `"""` docstring support (consistent with Starlark's Python heritage)
- Adds accuracy test fixture `tests/data/starlark.star`
- Updates README language list

## Note

`.bzl` (Bazel build files) was not included as it is already claimed by the existing `Bazel` language entry.

## Test plan

- [x] `cargo build` passes with no new warnings
- [x] `cargo test starlark` passes
- [x] `.fizz` files are correctly reported as `Starlark`

🤖 Generated with [Claude Code](https://claude.com/claude-code)