### PR TITLE
ci: add riscv64 to release targets

### DIFF
--- a/.github/workflows/mean_bean_deploy.yml
+++ b/.github/workflows/mean_bean_deploy.yml
@@ -138,6 +138,7 @@ jobs:
           - mipsel-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - powerpc64le-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
           - s390x-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl


### PR DESCRIPTION
Adds riscv64gc-unknown-linux-gnu to the Linux cross-compile target list. cross-rs already has riscv64 Dockerfiles so this should build via the existing cross pipeline.

Build validated on native riscv64: https://github.com/gounthar/tokei/actions/runs/23455596638