### PR TITLE
Improve Nextflow language support

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -1206,8 +1206,9 @@
     "Nextflow": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""]],
-      "extensions": ["nextflow", "nf"]
+      "quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""], ["'''", "'''"], ["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["nf"],
+      "filenames": ["nextflow.config"]
     },
     "Nim": {
       "line_comment": ["#"],

--- a/tests/data/nextflow.nf
+++ b/tests/data/nextflow.nf
@@ -1,18 +1,42 @@
-/* 18 lines 10 code 5 comments 3 blanks */
+// 42 lines 28 code 5 comments 9 blanks
 
 /*
-Nextflow - hello
-*/
+ * Multi-line block comment
+ */
 
-// comment
-cheers = Channel.from 'Bonjour', 'Ciao', 'Hello', 'Hola'
+// Single line comment
+nextflow.enable.dsl = 2
+
+params.greeting = 'Hello'
+params.name = "World"
 
 process sayHello {
-  echo true
-  input: 
-    val x from cheers
-  script:
+    input:
+    val greeting
+    val name
+
+    output:
+    stdout
+
+    script:
     """
-    echo '$x world!'
+    echo '${greeting}, ${name}!'
+    echo "// this is not a comment"
+    echo '/* also not a comment */'
     """
+}
+
+process farewell {
+    output:
+    stdout
+
+    script:
+    '''
+    echo 'Goodbye!'
+    '''
+}
+
+workflow {
+    sayHello(params.greeting, params.name) | view
+    farewell() | view
 }


### PR DESCRIPTION
## Summary

- Add triple-double (`"""`), triple-single (`'''`), and single (`'`) quote support to the Nextflow language definition — fixes miscounting of comment-like content inside process script blocks
- Add `nextflow.config` as a recognized filename
- Remove unused `nextflow` extension (Nextflow files use `.nf`)
- Rewrite test file as a realistic DSL2 pipeline exercising all quote/comment variants

## Test plan

- [x] `cargo test nextflow` — passes with 42 lines, 28 code, 5 comments, 9 blanks
- [x] `cargo test` — all 206 accuracy tests pass, no regressions
- [x] `cargo run -- --languages | grep -i nextflow` — Nextflow listed with `.nf` extension
- [x] `cargo run -- tests/data/nextflow.nf` — correct counts displayed

🤖 Generated with [Claude Code](https://claude.ai/code)