### PR TITLE
feat: add nasm extension to Assembly language

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -91,7 +91,7 @@
     "Assembly": {
       "line_comment": [";"],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "extensions": ["asm"]
+      "extensions": ["asm", "nasm"]
     },
     "AssemblyGAS": {
       "name": "GNU Style Assembly",


### PR DESCRIPTION
While "asm" is the common extension for assembly in general,
"nasm" is sometimes used to specifically signify files for NASM.
Since "asm" is also often used with NASM and its syntax is similar,
e.g. lacking the support for multi-line comments, it seems reasonable
to simply add the extension to the existing "Assembly" language, rather
than adding a new language all together.

Signed-off-by: Sandro-Alessio Gierens <sandro@gierens.de>
