### PR TITLE
fix: add support for backticks in Go language quotes

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -699,7 +699,7 @@
     "Go": {
       "line_comment": ["//"],
       "multi_line_comments": [["/*", "*/"]],
-      "quotes": [["\\\"", "\\\""]],
+      "quotes": [["\\\"", "\\\""], ["`", "`"]],
       "extensions": ["go"]
     },
     "Gohtml": {


### PR DESCRIPTION
Just adds backticks(\`) as quotes in Go in `language.json`

Edit: escape quote