### PR TITLE
Add Laravel Blade language support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -109,7 +109,13 @@ use super::*;
         let path = path.path();
         let root = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
-        let name = path.file_stem().unwrap().to_str().unwrap().to_lowercase();
+        let name = path
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_lowercase()
+            .replace('.', "_");
 
         if name == "jupyter" {
             continue;

--- a/languages.json
+++ b/languages.json
@@ -190,6 +190,13 @@
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
       "extensions": ["bb", "bbclass", "bbappend", "inc"]
     },
+    "Blade": {
+      "name": "Blade",
+      "multi_line_comments": [["{{--", "--}}"], ["<!--", "-->"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["blade"],
+      "path_suffixes": [".blade.php"]
+    },
     "Bqn": {
       "name": "BQN",
       "line_comment": ["#"],

--- a/src/language/language_type.tera.rs
+++ b/src/language/language_type.tera.rs
@@ -290,6 +290,16 @@ impl LanguageType {
                 {%- endfor %}
                 _ => ()
             }
+
+            {% for key, value in languages -%}
+                {%- if value.path_suffixes -%}
+                    {%- for suffix in value.path_suffixes %}
+            if filename.ends_with("{{suffix}}") {
+                return Some({{key}});
+            }
+                    {%- endfor %}
+                {% endif -%}
+            {%- endfor %}
         }
 
         match fsutils::get_extension(entry) {

--- a/tests/data/blade.blade.php
+++ b/tests/data/blade.blade.php
@@ -1,0 +1,23 @@
+{{-- 23 lines 15 code 5 comments 3 blanks --}}
+
+{{--
+    A welcome page demonstrating Blade syntax.
+--}}
+@extends('layouts.app')
+
+@section('content')
+    <!-- Page header -->
+    <div class="container">
+        <h1>{{ $title }}</h1>
+
+        @if ($users->isNotEmpty())
+            <ul class="list-group">
+                @foreach ($users as $user)
+                    <li>{{ $user->name }}</li>
+                @endforeach
+            </ul>
+        @else
+            <p>No users found.</p>
+        @endif
+    </div>
+@endsection


### PR DESCRIPTION
Laravel Blade: https://laravel.com/docs/12.x/blade

- Detect Blade by .blade extension and .blade.php compound suffix 
- Generic path_suffixes field for any future compound-extension language; matched in from_path before extension lookup so .blade.php wins over PHP
- Recognise Blade ({{-- --}}) and HTML (<!-- -->) multi-line comments
- Sanitise auto-generated test idents so blade.blade.php produces a valid Rust function name
- Add blade.blade.php fixture covering both comment styles