### PR TITLE
Add Vyper

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ VisualBasic
 VisualStudioProject
 VisualStudioSolution
 Vue
+Vyper
 WebAssembly
 Wolfram
 Xaml

--- a/languages.json
+++ b/languages.json
@@ -1142,7 +1142,7 @@
         ["(*", "*)"],
         ["/*", "*/"]
       ],
-      "extensions": ["mll", "mly", "vy"]
+      "extensions": ["mll", "mly"]
     },
     "Meson": {
       "line_comment": ["#"],
@@ -2028,6 +2028,13 @@
       "quotes": [["\\\"", "\\\""], ["'", "'"], ["`", "`"]],
       "important_syntax": ["<script", "<style", "<template"],
       "extensions": ["vue"]
+    },
+    "Vyper": {
+      "name": "Vyper",
+      "line_comment": ["#"],
+      "doc_quotes": [["\\\"\\\"\\\"", "\\\"\\\"\\\""], ["'''", "'''"]],
+      "quotes": [["\\\"", "\\\""], ["'", "'"]],
+      "extensions": ["vy"]
     },
     "WebAssembly": {
       "line_comment": [";;"],

--- a/tests/data/vyper.vy
+++ b/tests/data/vyper.vy
@@ -1,0 +1,49 @@
+# 49 lines 31 code 10 comments 8 blanks
+# ```vyper
+# @external
+# def main():
+#     # Comment
+#
+#     log Hello(message="Hello World!")
+# ```
+# pragma version ~=0.4.0
+
+event Hello:
+    message: String[32]
+
+owner: public(address)
+
+@deploy
+def __init__():
+    start: String[32] = "###\""
+    # comment
+    self.owner = msg.sender
+
+@internal
+def _call1():
+    return
+
+@internal
+def _call2():
+    return
+
+@external
+def foo(name: String[32]) -> String[64]:
+    this_ends: String[32] = "a \"test#."
+    self._call1()
+    self._call2()
+    this_does_not: String[64] = "# nested # phrase \" #"
+    return this_does_not
+
+@external
+def foobar() -> bool:
+    does_not_start: String[64] = "until here, test# test"  # a quote: "
+    also_doesnt_start: String[64] = "until here, test,# test"  # another quote: "
+    return True
+
+@external
+def foo_again() -> uint256:
+    a: uint256 = 4  # #
+    b: uint256 = 5
+    c: uint256 = 6  # #
+    return a + b + c


### PR DESCRIPTION
Adds the [Vyper](https://vyperlang.org/) language, which is a syntactical superset of Python.

Also removes `vy` from Menhir.
[Github](https://github.com/github-linguist/linguist/blob/5da575ee6562acc0ef89742d969a7d1b41a84457/lib/linguist/languages.yml#L8015-L8022), along with every other software forge, all treat `.vy` as Vyper. `vy` *is* used for Menhir, but only in [specific
circumstances](https://gallium.inria.fr/~fpottier/menhir/manual.html#sec2), and [Vyper is used far than
Menhir for `.vy` files](https://github.com/search?q=path%3A*.vy+NOT+is%3Afork&type=code).