### PR TITLE
Fix bug with `--files` mode subtotal printing

### DIFF
--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -438,7 +438,7 @@ impl<W: Write> Printer<W> {
             subtotal.stats += stats.summarise();
         }
 
-        self.print_report_with_name(report)?;
+        self.print_report_with_name(&subtotal)?;
 
         Ok(())
     }


### PR DESCRIPTION
Currently when printing file statistics with `--files`, multilanguage files appear like this:
```
...
-- .\src\cli.rs -----------------------------------------------------------------------------------------------------------------------------------------
 |- Rust                                                                                                      464          426            6           32
 |- Markdown                                                                                                   14            0           13            1
 .\src\cli.rs                                                                                                 464          426            6           32
...
```
The final row should be a subtotal for the file, but instead is a row named with the file path and containing repeated statistics for the primary language of the file, in this case Rust. This is because in `Printer::print_report_total`, `report` is passed to `print_report_with_name` instead of `subtotal`.

After this change, the output is:
```
...
-- .\src\cli.rs -----------------------------------------------------------------------------------------------------------------------------------------
 |- Rust                                                                                                      464          426            6           32
 |- Markdown                                                                                                   14            0           13            1
 |- (Total)                                                                                                   478          426           19           33
...
```