### PR TITLE
Fixed typo in command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ OPTIONS:
     -o, --output <output>         Outputs Tokei in a specific format. Compile with additional features for more format
                                   support. [possible values: cbor, json, yaml]
     -s, --sort <sort>             Sort languages based on column [possible values: files, lines, blanks, code, comments]
-    -t, --type <types>            Filters output by language type, separated by a comma. i.e. -t=Rust,Markdown
+    -t, --types <types>            Filters output by language type, separated by a comma. i.e. -t=Rust,Markdown
 
 ARGS:
     <input>...    The path(s) to the file or directory to be counted.


### PR DESCRIPTION
Fixed the typo in the the markdown, from `--type` to `--types`. Since it seemed to have been changed.

```sh
 ~ $: tokei --types Markdown
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Language              Files        Lines         Code     Comments       Blanks
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Markdown                  1           29            0           21            8
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Total                     1           29            0           21            8
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ~ $: tokei --type Markdown
error: unexpected argument '--type' found

  tip: a similar argument exists: '--types'

Usage: tokei --types <types> [input]...

For more information, try '--help'.
```