### PR TITLE
Add G# support

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Glsl
 Go
 Graphql
 Groovy
+GSharp
 Gwion
 Hamlet
 Handlebars

--- a/languages.json
+++ b/languages.json
@@ -728,6 +728,14 @@
       "env": ["groovy"],
       "extensions": ["groovy", "grt", "gtpl", "gvy"]
     },
+    "GSharp": {
+      "name": "G#",
+      "line_comment": ["//"],
+      "multi_line_comments": [["/*", "*/"]],
+      "quotes": [["\\\"", "\\\""]],
+      "verbatim_quotes": [["`", "`"]],
+      "extensions": ["gs"]
+    },
     "Gwion": {
       "line_comment": ["#!"],
       "quotes": [["\\\"", "\\\""]],
@@ -1203,7 +1211,7 @@
       "name": "MSBuild",
       "multi_line_comments": [["<!--", "-->"]],
       "quotes": [["\\\"", "\\\""], ["'", "'"]],
-      "extensions": ["csproj", "vbproj", "fsproj", "props", "targets"]
+      "extensions": ["csproj", "vbproj", "fsproj", "gsproj", "props", "targets"]
     },
     "Mustache": {
       "multi_line_comments": [["{{!", "}}"]],

--- a/tests/data/gsharp.gs
+++ b/tests/data/gsharp.gs
@@ -1,0 +1,26 @@
+// 26 lines 16 code 6 comments 4 blanks
+package GSharp.Example.Tokei
+
+import System
+
+/* A small greeter class that builds
+   a greeting from the stored name. */
+class Greeter(name string) {
+    /// Returns a personalized greeting.
+    func Greet() string {
+        // Interpolation is sigil-free in G#.
+        return "Hello, $name!"
+    }
+
+    func Query() string {
+        // Raw strings span lines and keep \ and // literally.
+        return `
+            SELECT *
+            FROM people // not a comment
+        `
+    }
+}
+
+let g = Greeter("world")
+Console.WriteLine(g.Greet())
+Console.WriteLine(g.Query())


### PR DESCRIPTION
Adds G# source code support to Tokei.
- Similar counting mechanics as C#, main difference is verbatim string use a different notation
- Added G# example test, loc counts look correct

Thanks!