### PR TITLE
Add Fluent language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Factor
 FEN
 Fish
 FlatBuffers
+Fluent
 ForgeConfig
 Forth
 FortranLegacy

--- a/languages.json
+++ b/languages.json
@@ -590,6 +590,11 @@
       "quotes": [["\\\"", "\\\""]],
       "extensions": ["fbs"]
     },
+    "Fluent": {
+      "line_comment": ["#"],
+      "quotes": [["\\\"", "\\\""]],
+      "extensions": ["flt"]
+    },
     "ForgeConfig": {
       "name": "Forge Config",
       "line_comment": ["#", "~"],

--- a/tests/data/fluent.flt
+++ b/tests/data/fluent.flt
@@ -1,0 +1,13 @@
+# 13 lines 8 code 3 comments 2 blanks
+### Resource-level comment
+
+hello = Hello, world!
+welcome = Welcome, { $name }!
+
+# Message comment
+shared-photos =
+    { $userName } added { $photoCount } new photos to { $userGender ->
+        [male] his stream
+       *[other] their stream
+    }.
+-brand-name = Firefox


### PR DESCRIPTION
Fluent is Mozilla's localization file format. Upstream Fluent files use the .ftl extension, but that is already claimed by FreeMarker, so this registers .flt to keep both languages detectable.