### PR TITLE
README: fix Chocolatey badge label typo and update CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Tokei ([時計](https://en.wiktionary.org/wiki/%E6%99%82%E8%A8%88))
-[![Mean Bean CI](https://github.com/XAMPPRocky/tokei/workflows/Mean%20Bean%20CI/badge.svg)](https://github.com/XAMPPRocky/tokei/actions?query=workflow%3A%22Mean+Bean+CI%22)
+[![Mean Bean CI](https://github.com/XAMPPRocky/tokei/actions/workflows/mean_bean_ci.yml/badge.svg)](https://github.com/XAMPPRocky/tokei/actions?query=workflow%3A%22Mean+Bean+CI%22)
 [![Help Wanted](https://img.shields.io/github/issues/XAMPPRocky/tokei/help%20wanted?color=green)](https://github.com/XAMPPRocky/tokei/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 [![Documentation](https://docs.rs/tokei/badge.svg)](https://docs.rs/tokei/)
 ![](https://img.shields.io/crates/d/tokei?label=downloads%20%28crates.io%29)
 ![](https://img.shields.io/github/downloads/xampprocky/tokei/total?label=downloads%20%28GH%29)
 ![](https://img.shields.io/homebrew/installs/dy/tokei?color=brightgreen&label=downloads%20%28brew%29)
-![Chocolatey Downloads](https://img.shields.io/chocolatey/dt/tokei?label=Downloads%20(Chocolately))
+![Chocolatey Downloads](https://img.shields.io/chocolatey/dt/tokei?label=Downloads%20(Chocolatey))
 [![dependency status](https://deps.rs/repo/github/XAMPPRocky/tokei/status.svg)](https://deps.rs/repo/github/XAMPPRocky/tokei)
 [![Packaging status](https://repology.org/badge/tiny-repos/tokei.svg)](https://repology.org/project/tokei/versions)
 


### PR DESCRIPTION
Two small fixes to the badge row at the top of the README:

- The Chocolatey downloads badge label read "Chocolately"; corrected to "Chocolatey".
- The Mean Bean CI badge used the legacy `/workflows/<Workflow%20Name>/badge.svg` URL form, which depends on the workflow's display name. Switched to the currently documented `/actions/workflows/mean_bean_ci.yml/badge.svg` form, which references the workflow file instead. Verified the new URL returns 200.

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MP2978RKk6fucsbVnafp55