### PR TITLE
feat: Add AL (Microsoft Dynamics 365 Business Central)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Abap
 ActionScript
 Ada
 Agda
+AL
 Alex
 Alloy
 APL

--- a/languages.json
+++ b/languages.json
@@ -25,6 +25,13 @@
       "multi_line_comments": [["{-", "-}"]],
       "extensions": ["agda"]
     },
+    "Al": {
+      "name": "AL",
+      "line_comment": ["//"],
+      "multi_line_comments": [["/*", "*/"]],
+      "quotes": [["'", "'"]],
+      "extensions": ["al"]
+    },
     "Alex": {
       "extensions": ["x"]
     },

--- a/tests/data/al.al
+++ b/tests/data/al.al
@@ -1,0 +1,33 @@
+// 33 lines 23 code 5 comments 5 blanks
+
+/* AL is the language of Microsoft Dynamics 365 Business Central.
+   This block comment spans three lines and should be counted
+   as three comment lines. */
+
+namespace MyCompany.Sales;
+
+using Microsoft.Foundation;
+
+table 50100 "My Table"
+{
+    fields
+    {
+        field(1; Name; Text[50])
+        {
+            Caption = 'Name';
+        }
+    }
+
+    /* a single line block comment */
+    procedure Compute(Value: Decimal): Decimal
+    var
+        Total: Decimal;
+        Note: Text;
+    begin
+        Total := Value * 2;  // double it
+        Note := 'It''s at https://example.com';
+        Note := 'not /* a comment */ either';
+        Note := '// not a comment either';
+        exit(Total);
+    end;
+}


### PR DESCRIPTION
Adds AL, the language of Microsoft Dynamics 365 Business Central.

## The language

AL is what Business Central extensions are written in. It is a recognised language in GitHub Linguist (since 2020), and has editor support in VS Code (Microsoft's own extension), Zed, Sublime Text and Helix.

## The definition

```json
"Al": {
  "name": "AL",
  "line_comment": ["//"],
  "multi_line_comments": [["/*", "*/"]],
  "quotes": [["'", "'"]],
  "extensions": ["al"]
},
```

The key follows Rust enum style with a `name` override, in the same way as `Sql`/`SQL`.

AL uses `//` line comments, `/* */` block comments, and single quoted string literals with an embedded quote written `''`.

## On the extension

`.al` is shared with Perl's AutoLoader, which is worth flagging because it does cause misclassification in other tools. It is not an issue here: nothing in `languages.json` currently claims `al`, and Perl is registered for `pl` and `pm` only. So this is a clean addition rather than a reassignment, and no existing count changes.

## Test file

`tests/data/al.al`, header verified by hand and by running tokei:

```
// 33 lines 23 code 5 comments 5 blanks
```

It covers a standalone line comment, a trailing line comment, a single line block comment, a multi-line block comment, and three strings that would break a naive counter:

```al
Note := 'It''s at https://example.com';
Note := 'not /* a comment */ either';
Note := '// not a comment either';
```

All three are counted as code, so neither comment syntax leaks out of a quoted string.

`cargo test` passes in full (251 tests), including the generated AL case.

AL is also added to the language list in `README.md`.

## AI disclosure

This change was prepared with AI assistance (Claude). The counts above were verified by hand and by running tokei locally.
