### PR TITLE
update readme: add OctoCounts to related tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,8 @@ please make your issues, and pull requests there.
 
 - [tokei-pie](https://github.com/laixintao/tokei-pie): Render tokei's output to
   interactive sunburst chart.
+- [OctoCounts](https://github.com/huanglizhuo/OctoCounts): GitHub SLOC counter
+  that adds file and line counts to GitHub repo pages using tokei.
 
 ## Copyright and License
 (C) Copyright 2015 by XAMPPRocky and contributors


### PR DESCRIPTION
Hi! I built [OctoCounts](https://github.com/huanglizhuo/OctoCounts), a GitHub SLOC (Source Lines of Code) counter.

It shows file and line counts for GitHub repositories, both as a [browser extension](https://chromewebstore.google.com/detail/octocounts-%E2%80%94-github-sloc/gkgjpjdnaklagijmekoolhcpebmoldbj) on repo pages and via a [web app](https://octocounts.com/), and it uses tokei under the hood to count lines.

I added it to the Related Tools section following the existing format. Happy to close this if you prefer not to include it.