### PR TITLE
fix: --files panics on a path longer than the row width

### DIFF
--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -369,11 +369,9 @@ impl<W: Write> Printer<W> {
                                             self.writer,
                                             "-- {} {}",
                                             report.name.display(),
-                                            "-".repeat(
-                                                self.columns
-                                                    - 4
-                                                    - report.name.display().to_string().len()
-                                            )
+                                            "-".repeat(self.columns.saturating_sub(
+                                                4 + report.name.display().to_string().len()
+                                            ))
                                         )?;
                                     }
                                     let mut new_report = (*report).clone();
@@ -488,5 +486,49 @@ impl<W: Write> Printer<W> {
         self.print_row()?;
         self.print_language_in_print_total(&total)?;
         self.print_row()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consts::FALLBACK_ROW_LEN;
+    use std::collections::BTreeMap;
+
+    fn report(name: &str, with_blob: bool) -> Report {
+        let mut report = Report::new(name.into());
+        report.stats.code = 1;
+        if with_blob {
+            report
+                .stats
+                .blobs
+                .insert(LanguageType::Markdown, CodeStats::new());
+        }
+        report
+    }
+
+    /// A path longer than the row width must not overflow the separator's
+    /// `"-".repeat(..)` length.
+    #[test]
+    fn long_path_with_embedded_language_does_not_overflow() {
+        let long = "a".repeat(FALLBACK_ROW_LEN + 10);
+
+        let mut language = Language::new();
+        // a plain report first, so the embedded one takes the `--` separator branch
+        language.add_report(report("short.rs", false));
+        language.add_report(report(&long, true));
+
+        let mut languages = BTreeMap::new();
+        languages.insert(LanguageType::Rust, language);
+
+        let mut printer = Printer::new(
+            FALLBACK_ROW_LEN,
+            true,
+            Vec::new(),
+            NumberFormatStyle::Plain.get_format().unwrap(),
+        );
+        printer
+            .print_results(languages.iter(), false, false)
+            .unwrap();
     }
 }


### PR DESCRIPTION
## What's broken

`tokei --files` aborts on a file whose path is longer than the row width, if that file also contains an embedded language.

```
$ tokei --files /tmp/d
thread 'main' panicked at library/alloc/src/raw_vec/mod.rs:28:5:
capacity overflow
```

Reproduced with a directory holding one ordinary `b.rs` plus one `.rs` file with a 90 character name containing a doc comment with a fenced `rust` block. The embedded language is what routes the report through the `--` separator branch; the long name is what breaks it there.

Debug builds name it directly:

```
attempt to subtract with overflow, at src/cli_utils.rs:373
```

A long path is not exotic. A deep `node_modules` or a nested monorepo package reaches 80 columns easily, and the file that trips it is any source file with a fenced code block in a doc comment.

## Cause

```rust
"-".repeat(self.columns - 4 - report.name.display().to_string().len())
```

Both operands are `usize`. Once the name plus 4 exceeds the row width the subtraction wraps to a huge value, and `repeat` is asked for a string of about `usize::MAX` bytes. Release builds surface it as `capacity overflow` from the allocator rather than as the subtraction it actually is, which is why the panic message points at `raw_vec` and not at tokei.

## The fix

`saturating_sub`, so an over-long name yields no dashes instead of wrapping. The name is already wider than the row, so zero separator dashes is the right answer as well as the safe one.

After, the same command prints the full table and exits 0.

## Verification

A unit test in `src/cli_utils.rs` builds a `Printer` at `FALLBACK_ROW_LEN` and prints two reports, one ordinary and one whose name is longer than the row and which carries a blob, so it takes the separator branch. The test asserts nothing beyond completing, because the defect is a panic.

Restoring the plain subtraction while keeping the test fails it:

```
test cli_utils::tests::long_path_with_embedded_language_does_not_overflow ... FAILED
panicked at src/cli_utils.rs:373:49: attempt to subtract with overflow
```

`cargo test` is 20 + 2 + 207 + 22 passed, 0 failed. `cargo fmt --check` is clean.
